### PR TITLE
Fix QuickStartTile's onClick handler

### DIFF
--- a/packages/dev/src/CustomCatalog.tsx
+++ b/packages/dev/src/CustomCatalog.tsx
@@ -93,7 +93,7 @@ export const CustomCatalog: React.FC = () => {
               } = quickStart;
 
               return (
-                <GalleryItem key={id}>
+                <GalleryItem key={id} className="co-quick-start-catalog__gallery-item">
                   <QuickStartTile
                     quickStart={quickStart}
                     isActive={id === activeQuickStartID}

--- a/packages/module/src/catalog/QuickStartCatalog.scss
+++ b/packages/module/src/catalog/QuickStartCatalog.scss
@@ -2,4 +2,7 @@
   &__gallery {
     --pf-l-gallery--GridTemplateColumns: repeat(auto-fill, 300px) !important;
   }
+  &__gallery-item {
+    display: inherit !important;
+  }
 }

--- a/packages/module/src/catalog/QuickStartCatalog.tsx
+++ b/packages/module/src/catalog/QuickStartCatalog.tsx
@@ -25,7 +25,7 @@ const QuickStartCatalog: React.FC<QuickStartCatalogProps> = ({ quickStarts }) =>
           } = quickStart;
 
           return (
-            <GalleryItem key={id}>
+            <GalleryItem key={id} className="co-quick-start-catalog__gallery-item">
               <QuickStartTile
                 quickStart={quickStart}
                 isActive={id === activeQuickStartID}

--- a/packages/module/src/catalog/QuickStartTile.tsx
+++ b/packages/module/src/catalog/QuickStartTile.tsx
@@ -34,6 +34,8 @@ const QuickStartTile: React.FC<QuickStartTileProps> = ({
     QuickStartContext,
   );
 
+  const ref = React.useRef<HTMLDivElement>(null);
+
   const quickStartIcon = (
     <FallbackImg
       className="co-catalog-item-icon__img--large"
@@ -49,39 +51,45 @@ const QuickStartTile: React.FC<QuickStartTileProps> = ({
       <QuickStartTileFooter quickStartId={id} status={status} totalTasks={tasks?.length} />
     );
 
+  const handleClick = (e: React.SyntheticEvent<HTMLElement, Event>) => {
+    if (ref.current?.contains(e.target as Node)) {
+      if (link) {
+        window.open(link.href);
+      } else {
+        setActiveQuickStart(id, tasks?.length);
+      }
+      onClick();
+    }
+  };
+
   return (
-    <CatalogTile
-      // @ts-ignore
-      component="div"
-      style={{
-        cursor: 'pointer',
-      }}
-      icon={quickStartIcon}
-      className="co-quick-start-tile"
-      data-testid={`qs-card-${camelize(displayName)}`}
-      featured={isActive}
-      title={
-        <QuickStartTileHeader
-          name={displayName}
-          status={status}
-          duration={durationMinutes}
-          type={type}
-        />
-      }
-      onClick={() => {
-        if (link) {
-          window.open(link.href);
-        } else {
-          setActiveQuickStart(id, tasks?.length);
+    <div ref={ref}>
+      <CatalogTile
+        // @ts-ignore
+        component="div"
+        style={{
+          cursor: 'pointer',
+        }}
+        icon={quickStartIcon}
+        className="co-quick-start-tile"
+        data-testid={`qs-card-${camelize(displayName)}`}
+        featured={isActive}
+        title={
+          <QuickStartTileHeader
+            name={displayName}
+            status={status}
+            duration={durationMinutes}
+            type={type}
+          />
         }
-        onClick();
-      }}
-      data-test={`tile ${id}`}
-      description={
-        <QuickStartTileDescription description={description} prerequisites={prerequisites} />
-      }
-      footer={footerComponent}
-    />
+        onClick={handleClick}
+        data-test={`tile ${id}`}
+        description={
+          <QuickStartTileDescription description={description} prerequisites={prerequisites} />
+        }
+        footer={footerComponent}
+      />
+    </div>
   );
 };
 


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ODC-6091

This PR fixes the issue wherein clicking on prerequisites popover, quickstart sidebar was getting closed if open and getting open if closed. It was because the popover click event was getting propagated to the tile and hence its onClick handler was getting executed. Fixed this issue by checking if the clicked element is inside the tile and if yes then only open/close the sidebar.


https://user-images.githubusercontent.com/20724543/124779970-da29ed00-df5f-11eb-9540-a943642008a3.mov