### PR TITLE
Fix missing shadow when user can scroll content

### DIFF
--- a/packages/module/src/QuickStartPanelContent.scss
+++ b/packages/module/src/QuickStartPanelContent.scss
@@ -1,9 +1,12 @@
 .co-quick-start-panel-content {
-  &-head {
+  &__header {
     position: sticky;
     top: 0px;
     background: inherit;
     z-index: var(--pf-global--ZIndex--xs);
+    &__shadow {
+      box-shadow: var(--pf-global--BoxShadow--sm-bottom);
+    }
   }
   &__body {
     display: flex;
@@ -19,5 +22,10 @@
   }
   &__duration {
     display: inline-block;
+  }
+  &__footer {
+    &__shadow {
+      box-shadow: var(--pf-global--BoxShadow--sm-top);
+    }
   }
 }

--- a/packages/module/src/QuickStartPanelContent.tsx
+++ b/packages/module/src/QuickStartPanelContent.tsx
@@ -53,12 +53,14 @@ const QuickStartPanelContent: React.FC<QuickStartPanelContentProps> = ({
     quickStart?.spec.nextQuickStart?.includes(qs.metadata.name),
   );
 
-  const headerClasses = classNames({
-    'pf-u-box-shadow-sm-bottom': shadows === Shadows.top || shadows === Shadows.both,
+  const headerClasses = classNames('co-quick-start-panel-content__header', {
+    'co-quick-start-panel-content__header__shadow':
+      shadows === Shadows.top || shadows === Shadows.both,
   });
 
   const footerClass = classNames({
-    'pf-u-box-shadow-sm-top': shadows === Shadows.bottom || shadows === Shadows.both,
+    'co-quick-start-panel-content__footer__shadow':
+      shadows === Shadows.bottom || shadows === Shadows.both,
   });
 
   const getStep = () => {
@@ -81,7 +83,7 @@ const QuickStartPanelContent: React.FC<QuickStartPanelContentProps> = ({
       data-test="quickstart drawer"
       {...props}
     >
-      <div className={`co-quick-start-panel-content-head ${headerClasses}`}>
+      <div className={headerClasses}>
         <DrawerHead>
           <div className="co-quick-start-panel-content__title">
             <Title


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-6159

This PR restore a shadow which was earlier shown in the QuickStart content when the user can scroll the content in a small window (or with a long content). This is similar to OpenShift console issue https://github.com/openshift/console/pull/9527

**Before (main):**
![missing-shadow](https://user-images.githubusercontent.com/139310/125823470-171043e9-a01c-46cd-91af-a8072870db39.gif)

**After (with this PR):**
![missing-shadow-fixed](https://user-images.githubusercontent.com/139310/125823479-ade1c556-ac6c-4da4-9f22-10246eaa12f1.gif)
