### PR TITLE
Rename classes

### DIFF
--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@patternfly/quickstarts": "1.1.0-rc.2",
-    "@patternfly/react-core": "^4.101.3",
+    "@patternfly/react-core": "^4.135.0",
     "asciidoctor": "^2.2.1",
     "i18next": "^19.8.3",
     "i18next-browser-languagedetector": "^6.0.1",

--- a/packages/dev/src/CustomCatalog.tsx
+++ b/packages/dev/src/CustomCatalog.tsx
@@ -93,7 +93,7 @@ export const CustomCatalog: React.FC = () => {
             Step-by-step instructions and tasks
           </Text>
         </TextContent>
-        <Gallery className="pfe-quick-start-catalog__gallery" hasGutter>
+        <Gallery className="pfext-quick-start-catalog__gallery" hasGutter>
           {allQuickStarts
             .filter(
               (quickStart: QuickStart) =>
@@ -105,7 +105,7 @@ export const CustomCatalog: React.FC = () => {
               } = quickStart;
 
               return (
-                <GalleryItem key={id} className="pfe-quick-start-catalog__gallery-item">
+                <GalleryItem key={id} className="pfext-quick-start-catalog__gallery-item">
                   <QuickStartTile
                     quickStart={quickStart}
                     isActive={id === activeQuickStartID}
@@ -124,7 +124,7 @@ export const CustomCatalog: React.FC = () => {
           <Text component="h2">Documentation</Text>
           <Text component="p">Technical information for using the service</Text>
         </TextContent>
-        <Gallery className="pfe-quick-start-catalog__gallery" hasGutter>
+        <Gallery className="pfext-quick-start-catalog__gallery" hasGutter>
           {allQuickStarts
             .filter((quickStart: QuickStart) => quickStart.spec.type?.text === 'Documentation')
             .map((quickStart: QuickStart) => {

--- a/packages/dev/src/CustomCatalog.tsx
+++ b/packages/dev/src/CustomCatalog.tsx
@@ -93,7 +93,7 @@ export const CustomCatalog: React.FC = () => {
             Step-by-step instructions and tasks
           </Text>
         </TextContent>
-        <Gallery className="co-quick-start-catalog__gallery" hasGutter>
+        <Gallery className="pfe-quick-start-catalog__gallery" hasGutter>
           {allQuickStarts
             .filter(
               (quickStart: QuickStart) =>
@@ -105,7 +105,7 @@ export const CustomCatalog: React.FC = () => {
               } = quickStart;
 
               return (
-                <GalleryItem key={id} className="co-quick-start-catalog__gallery-item">
+                <GalleryItem key={id} className="pfe-quick-start-catalog__gallery-item">
                   <QuickStartTile
                     quickStart={quickStart}
                     isActive={id === activeQuickStartID}
@@ -124,7 +124,7 @@ export const CustomCatalog: React.FC = () => {
           <Text component="h2">Documentation</Text>
           <Text component="p">Technical information for using the service</Text>
         </TextContent>
-        <Gallery className="co-quick-start-catalog__gallery" hasGutter>
+        <Gallery className="pfe-quick-start-catalog__gallery" hasGutter>
           {allQuickStarts
             .filter((quickStart: QuickStart) => quickStart.spec.type?.text === 'Documentation')
             .map((quickStart: QuickStart) => {

--- a/packages/dev/src/quickstarts-data/mocks/html/adding_health_checks.quickstart.html
+++ b/packages/dev/src/quickstarts-data/mocks/html/adding_health_checks.quickstart.html
@@ -34,7 +34,7 @@
     var cpDocumentations = document.querySelectorAll('cp-documentation');
     for (let index = 0; index < cpDocumentations.length; index++) {
       const cpDocumentation = cpDocumentations[index];
-      cpDocumentation.setAttribute('pfext-c-non-prod', '');
+      cpDocumentation.setAttribute('pfe-c-non-prod', '');
     }
   });
 </script>

--- a/packages/dev/src/quickstarts-data/mocks/html/adding_health_checks.quickstart.html
+++ b/packages/dev/src/quickstarts-data/mocks/html/adding_health_checks.quickstart.html
@@ -34,7 +34,7 @@
     var cpDocumentations = document.querySelectorAll('cp-documentation');
     for (let index = 0; index < cpDocumentations.length; index++) {
       const cpDocumentation = cpDocumentations[index];
-      cpDocumentation.setAttribute('pfe-c-non-prod', '');
+      cpDocumentation.setAttribute('pfext-c-non-prod', '');
     }
   });
 </script>

--- a/packages/module/package.json
+++ b/packages/module/package.json
@@ -44,8 +44,7 @@
     "bootstrap-sass": "^3.3.7",
     "dompurify": "^2.2.6",
     "history": "^5.0.0",
-    "showdown": "1.8.6",
-    "@patternfly/react-catalog-view-extension": "4.12.15"
+    "showdown": "1.8.6"
   },
   "devDependencies": {
     "@patternfly/patternfly": "4.122.2",

--- a/packages/module/package.json
+++ b/packages/module/package.json
@@ -37,7 +37,7 @@
   "peerDependencies": {
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "@patternfly/react-core": ">=4.101.3",
+    "@patternfly/react-core": ">=4.115.2",
     "showdown": ">=1.8.6"
   },
   "dependencies": {

--- a/packages/module/src/ConsoleInternal/components/_icon-and-text.scss
+++ b/packages/module/src/ConsoleInternal/components/_icon-and-text.scss
@@ -1,6 +1,6 @@
-$co-icon-and-text-icon-lg: 1.2rem;
+$pfe-icon-and-text-icon-lg: 1.2rem;
 
-.co-icon-and-text {
+.pfe-icon-and-text {
   align-items: baseline;
   display: flex;
 
@@ -10,16 +10,16 @@ $co-icon-and-text-icon-lg: 1.2rem;
   }
 }
 
-.co-icon-and-text__icon {
+.pfe-icon-and-text__icon {
   flex-shrink: 0;
   margin-right: 5px;
 }
 
-.co-icon-and-text--lg {
+.pfe-icon-and-text--lg {
   display: block;
 
-  .co-icon-and-text__icon {
-    font-size: $co-icon-and-text-icon-lg;
+  .pfe-icon-and-text__icon {
+    font-size: $pfe-icon-and-text-icon-lg;
     margin-right: 1rem;
   }
 }

--- a/packages/module/src/ConsoleInternal/components/_icon-and-text.scss
+++ b/packages/module/src/ConsoleInternal/components/_icon-and-text.scss
@@ -1,6 +1,6 @@
-$pfe-icon-and-text-icon-lg: 1.2rem;
+$pfext-icon-and-text-icon-lg: 1.2rem;
 
-.pfe-icon-and-text {
+.pfext-icon-and-text {
   align-items: baseline;
   display: flex;
 
@@ -10,16 +10,16 @@ $pfe-icon-and-text-icon-lg: 1.2rem;
   }
 }
 
-.pfe-icon-and-text__icon {
+.pfext-icon-and-text__icon {
   flex-shrink: 0;
   margin-right: 5px;
 }
 
-.pfe-icon-and-text--lg {
+.pfext-icon-and-text--lg {
   display: block;
 
-  .pfe-icon-and-text__icon {
-    font-size: $pfe-icon-and-text-icon-lg;
+  .pfext-icon-and-text__icon {
+    font-size: $pfext-icon-and-text-icon-lg;
     margin-right: 1rem;
   }
 }

--- a/packages/module/src/ConsoleInternal/components/_markdown-view.scss
+++ b/packages/module/src/ConsoleInternal/components/_markdown-view.scss
@@ -1,4 +1,4 @@
-.co-markdown-view {
+.pfe-markdown-view {
   &.is-empty {
     color: #999;
   }

--- a/packages/module/src/ConsoleInternal/components/_markdown-view.scss
+++ b/packages/module/src/ConsoleInternal/components/_markdown-view.scss
@@ -1,4 +1,4 @@
-.pfe-markdown-view {
+.pfext-markdown-view {
   &.is-empty {
     color: #999;
   }

--- a/packages/module/src/ConsoleInternal/components/catalog/_catalog.scss
+++ b/packages/module/src/ConsoleInternal/components/catalog/_catalog.scss
@@ -1,15 +1,15 @@
 // frontend/public/style/_vars.scss
 $font-size-base: 14px;
-$co-m-catalog-tile-height: 100%;
-$co-m-catalog-tile-width: 260px;
+$pfe-m-catalog-tile-height: 100%;
+$pfe-m-catalog-tile-width: 260px;
 
 $catalog-capability-level-icon-left: -20px;
 $catalog-capability-level-icon-top: 4px;
 $catalog-capability-level-inactive-color: var(--pf-global--Color--400);
 $catalog-item-icon-size-lg: 40px;
 $catalog-item-icon-size-sm: 24px;
-$co-modal-ignore-warning-icon-width: 30px;
-$catalog-tile-width: $co-m-catalog-tile-width;
+$pfe-modal-ignore-warning-icon-width: 30px;
+$catalog-tile-width: $pfe-m-catalog-tile-width;
 
 // reset font size back to 13px since console h5 font size is 14px
 .catalog-item-header-pf-subtitle {
@@ -20,27 +20,27 @@ $catalog-tile-width: $co-m-catalog-tile-width;
   font-size: ($font-size-base - 1);
 }
 
-.co-catalog {
+.pfe-catalog {
   display: flex;
   flex-direction: column;
   min-height: 100%;
   min-width: 515px; // in order to accommodate filters and tiles at mobile
 }
 
-.co-catalog-tile-view {
+.pfe-catalog-tile-view {
   display: flex;
   flex-wrap: wrap;
   --pf-l-gallery--GridTemplateColumns: repeat(auto-fill, 260px) !important;
 }
 
-.co-catalog__body {
-  min-width: 575px; // Minimum shrinkable width of .co-catalog child elements => 15 + ((220 + 15) + (30 + 250 + 30)) + 15
+.pfe-catalog__body {
+  min-width: 575px; // Minimum shrinkable width of .pfe-catalog child elements => 15 + ((220 + 15) + (30 + 250 + 30)) + 15
   @media (min-width: $screen-sm-min) {
     min-width: 590px; // Left margin 30 instead of 15
   }
 }
 
-.co-catalog-item-details {
+.pfe-catalog-item-details {
   display: flex;
   margin: 0 0 10px;
 
@@ -69,7 +69,7 @@ $catalog-tile-width: $co-m-catalog-tile-width;
   }
 }
 
-.co-catalog-item-icon {
+.pfe-catalog-item-icon {
   padding-right: 10px;
 
   &__icon {
@@ -99,7 +99,7 @@ $catalog-tile-width: $co-m-catalog-tile-width;
   }
 }
 
-.co-catalog-page {
+.pfe-catalog-page {
   background: $color-pf-white;
   border: 1px solid var(--pf-global--BorderColor--300);
   display: flex;
@@ -192,7 +192,7 @@ $catalog-tile-width: $co-m-catalog-tile-width;
   &__overlay {
     border: 0 !important; // Collapse default PF4 modal border-width
 
-    .modal-body .co-hint-block {
+    .modal-body .pfe-hint-block {
       margin-bottom: 10px;
     }
 
@@ -301,22 +301,22 @@ $catalog-tile-width: $co-m-catalog-tile-width;
 }
 
 @media screen and (min-width: $screen-sm) {
-  .pf-c-modal-box.co-catalog-page__overlay {
+  .pf-c-modal-box.pfe-catalog-page__overlay {
     width: 600px;
   }
 }
 
 @media screen and (min-width: $screen-md) {
-  .pf-c-modal-box.co-catalog-page__overlay {
+  .pf-c-modal-box.pfe-catalog-page__overlay {
     width: 900px;
   }
 }
 
-.co-catalog-tab__empty {
+.pfe-catalog-tab__empty {
   color: $color-pf-black-600;
 }
 
-.co-modal-ignore-warning {
+.pfe-modal-ignore-warning {
   height: initial;
 
   &__checkbox.checkbox {
@@ -327,10 +327,10 @@ $catalog-tile-width: $co-m-catalog-tile-width;
     display: flex;
   }
   &__icon {
-    font-size: $co-modal-ignore-warning-icon-width;
+    font-size: $pfe-modal-ignore-warning-icon-width;
     margin-right: 15px;
     // Avoid the dialog shifting when the icon loads.
-    min-width: $co-modal-ignore-warning-icon-width;
+    min-width: $pfe-modal-ignore-warning-icon-width;
   }
   &__link {
     display: block;

--- a/packages/module/src/ConsoleInternal/components/catalog/_catalog.scss
+++ b/packages/module/src/ConsoleInternal/components/catalog/_catalog.scss
@@ -1,15 +1,15 @@
 // frontend/public/style/_vars.scss
 $font-size-base: 14px;
-$pfe-m-catalog-tile-height: 100%;
-$pfe-m-catalog-tile-width: 260px;
+$pfext-m-catalog-tile-height: 100%;
+$pfext-m-catalog-tile-width: 260px;
 
 $catalog-capability-level-icon-left: -20px;
 $catalog-capability-level-icon-top: 4px;
 $catalog-capability-level-inactive-color: var(--pf-global--Color--400);
 $catalog-item-icon-size-lg: 40px;
 $catalog-item-icon-size-sm: 24px;
-$pfe-modal-ignore-warning-icon-width: 30px;
-$catalog-tile-width: $pfe-m-catalog-tile-width;
+$pfext-modal-ignore-warning-icon-width: 30px;
+$catalog-tile-width: $pfext-m-catalog-tile-width;
 
 // reset font size back to 13px since console h5 font size is 14px
 .catalog-item-header-pf-subtitle {
@@ -20,27 +20,27 @@ $catalog-tile-width: $pfe-m-catalog-tile-width;
   font-size: ($font-size-base - 1);
 }
 
-.pfe-catalog {
+.pfext-catalog {
   display: flex;
   flex-direction: column;
   min-height: 100%;
   min-width: 515px; // in order to accommodate filters and tiles at mobile
 }
 
-.pfe-catalog-tile-view {
+.pfext-catalog-tile-view {
   display: flex;
   flex-wrap: wrap;
   --pf-l-gallery--GridTemplateColumns: repeat(auto-fill, 260px) !important;
 }
 
-.pfe-catalog__body {
-  min-width: 575px; // Minimum shrinkable width of .pfe-catalog child elements => 15 + ((220 + 15) + (30 + 250 + 30)) + 15
+.pfext-catalog__body {
+  min-width: 575px; // Minimum shrinkable width of .pfext-catalog child elements => 15 + ((220 + 15) + (30 + 250 + 30)) + 15
   @media (min-width: $screen-sm-min) {
     min-width: 590px; // Left margin 30 instead of 15
   }
 }
 
-.pfe-catalog-item-details {
+.pfext-catalog-item-details {
   display: flex;
   margin: 0 0 10px;
 
@@ -69,7 +69,7 @@ $catalog-tile-width: $pfe-m-catalog-tile-width;
   }
 }
 
-.pfe-catalog-item-icon {
+.pfext-catalog-item-icon {
   padding-right: 10px;
 
   &__icon {
@@ -99,7 +99,7 @@ $catalog-tile-width: $pfe-m-catalog-tile-width;
   }
 }
 
-.pfe-catalog-page {
+.pfext-catalog-page {
   background: $color-pf-white;
   border: 1px solid var(--pf-global--BorderColor--300);
   display: flex;
@@ -192,7 +192,7 @@ $catalog-tile-width: $pfe-m-catalog-tile-width;
   &__overlay {
     border: 0 !important; // Collapse default PF4 modal border-width
 
-    .modal-body .pfe-hint-block {
+    .modal-body .pfext-hint-block {
       margin-bottom: 10px;
     }
 
@@ -301,22 +301,22 @@ $catalog-tile-width: $pfe-m-catalog-tile-width;
 }
 
 @media screen and (min-width: $screen-sm) {
-  .pf-c-modal-box.pfe-catalog-page__overlay {
+  .pf-c-modal-box.pfext-catalog-page__overlay {
     width: 600px;
   }
 }
 
 @media screen and (min-width: $screen-md) {
-  .pf-c-modal-box.pfe-catalog-page__overlay {
+  .pf-c-modal-box.pfext-catalog-page__overlay {
     width: 900px;
   }
 }
 
-.pfe-catalog-tab__empty {
+.pfext-catalog-tab__empty {
   color: $color-pf-black-600;
 }
 
-.pfe-modal-ignore-warning {
+.pfext-modal-ignore-warning {
   height: initial;
 
   &__checkbox.checkbox {
@@ -327,10 +327,10 @@ $catalog-tile-width: $pfe-m-catalog-tile-width;
     display: flex;
   }
   &__icon {
-    font-size: $pfe-modal-ignore-warning-icon-width;
+    font-size: $pfext-modal-ignore-warning-icon-width;
     margin-right: 15px;
     // Avoid the dialog shifting when the icon loads.
-    min-width: $pfe-modal-ignore-warning-icon-width;
+    min-width: $pfext-modal-ignore-warning-icon-width;
   }
   &__link {
     display: block;

--- a/packages/module/src/ConsoleInternal/components/markdown-view.tsx
+++ b/packages/module/src/ConsoleInternal/components/markdown-view.tsx
@@ -170,7 +170,7 @@ const InlineMarkdownView: React.FC<InnerSyncMarkdownProps> = ({
 }) => {
   const id = React.useMemo(() => uniqueId('markdown'), []);
   return (
-    <div className={css('pfe-markdown-view', { 'is-empty': isEmpty }, className)} id={id}>
+    <div className={css('pfext-markdown-view', { 'is-empty': isEmpty }, className)} id={id}>
       <div dangerouslySetInnerHTML={{ __html: markup }} />
       {renderExtension && (
         <RenderExtension renderExtension={renderExtension} selector={`#${id}`} markup={markup} />

--- a/packages/module/src/ConsoleInternal/components/markdown-view.tsx
+++ b/packages/module/src/ConsoleInternal/components/markdown-view.tsx
@@ -170,7 +170,7 @@ const InlineMarkdownView: React.FC<InnerSyncMarkdownProps> = ({
 }) => {
   const id = React.useMemo(() => uniqueId('markdown'), []);
   return (
-    <div className={css('co-markdown-view', { 'is-empty': isEmpty }, className)} id={id}>
+    <div className={css('pfe-markdown-view', { 'is-empty': isEmpty }, className)} id={id}>
       <div dangerouslySetInnerHTML={{ __html: markup }} />
       {renderExtension && (
         <RenderExtension renderExtension={renderExtension} selector={`#${id}`} markup={markup} />

--- a/packages/module/src/ConsoleInternal/components/utils/status-box.tsx
+++ b/packages/module/src/ConsoleInternal/components/utils/status-box.tsx
@@ -2,18 +2,15 @@ import * as React from 'react';
 import { css } from '@patternfly/react-styles';
 import { QuickStartContext, QuickStartContextValues } from '../../../utils/quick-start-context';
 
-// import * as restrictedSignImg from '../../imgs/restricted-sign.svg';
-// import { TimeoutError } from '../../co-fetch';
-
 export const Box: React.FC<BoxProps> = ({ children, className }) => (
   <div className={css('cos-status-box', className)}>{children}</div>
 );
 
 export const Loading: React.FC<LoadingProps> = ({ className }) => (
-  <div className={css('co-m-loader co-an-fade-in-out', className)}>
-    <div className="co-m-loader-dot__one" />
-    <div className="co-m-loader-dot__two" />
-    <div className="co-m-loader-dot__three" />
+  <div className={css('pfe-m-loader pfe-an-fade-in-out', className)}>
+    <div className="pfe-m-loader-dot__one" />
+    <div className="pfe-m-loader-dot__two" />
+    <div className="pfe-m-loader-dot__three" />
   </div>
 );
 Loading.displayName = 'Loading';

--- a/packages/module/src/ConsoleInternal/components/utils/status-box.tsx
+++ b/packages/module/src/ConsoleInternal/components/utils/status-box.tsx
@@ -7,10 +7,10 @@ export const Box: React.FC<BoxProps> = ({ children, className }) => (
 );
 
 export const Loading: React.FC<LoadingProps> = ({ className }) => (
-  <div className={css('pfe-m-loader pfe-an-fade-in-out', className)}>
-    <div className="pfe-m-loader-dot__one" />
-    <div className="pfe-m-loader-dot__two" />
-    <div className="pfe-m-loader-dot__three" />
+  <div className={css('pfext-m-loader pfext-an-fade-in-out', className)}>
+    <div className="pfext-m-loader-dot__one" />
+    <div className="pfext-m-loader-dot__two" />
+    <div className="pfext-m-loader-dot__three" />
   </div>
 );
 Loading.displayName = 'Loading';

--- a/packages/module/src/ConsoleInternal/style.scss
+++ b/packages/module/src/ConsoleInternal/style.scss
@@ -5,7 +5,7 @@
 @import 'components/icon-and-text';
 @import 'components/catalog/catalog';
 
-.co-quick-start-panel-content,
+.pfe-quick-start-panel-content,
 .ocs-page-layout__content,
 .ocs-page-layout__base {
   --pf-global--FontSize--md: 14px;

--- a/packages/module/src/ConsoleInternal/style.scss
+++ b/packages/module/src/ConsoleInternal/style.scss
@@ -5,9 +5,12 @@
 @import 'components/icon-and-text';
 @import 'components/catalog/catalog';
 
+// drawer
 .pfext-quick-start-panel-content,
-.ocs-page-layout__content,
-.ocs-page-layout__base {
+// catalog gallery wrapper
+.pfext-page-layout__content,
+// catalog item prereq popover
+.pfext-page-layout__base {
   --pf-global--FontSize--md: 14px;
   --pf-global--FontSize--sm: 13px;
 

--- a/packages/module/src/ConsoleInternal/style.scss
+++ b/packages/module/src/ConsoleInternal/style.scss
@@ -5,7 +5,7 @@
 @import 'components/icon-and-text';
 @import 'components/catalog/catalog';
 
-.pfe-quick-start-panel-content,
+.pfext-quick-start-panel-content,
 .ocs-page-layout__content,
 .ocs-page-layout__base {
   --pf-global--FontSize--md: 14px;

--- a/packages/module/src/ConsoleInternal/style/_base.scss
+++ b/packages/module/src/ConsoleInternal/style/_base.scss
@@ -1,6 +1,6 @@
 // Base element styles.
 // Please DO NOT add rules of this type.
-.pfe-quick-start-panel-content {
+.pfext-quick-start-panel-content {
   dl {
     margin: 0px; }
 

--- a/packages/module/src/ConsoleInternal/style/_base.scss
+++ b/packages/module/src/ConsoleInternal/style/_base.scss
@@ -1,6 +1,6 @@
 // Base element styles.
 // Please DO NOT add rules of this type.
-.co-quick-start-panel-content {
+.pfe-quick-start-panel-content {
   dl {
     margin: 0px; }
 

--- a/packages/module/src/ConsoleInternal/style/_vars.scss
+++ b/packages/module/src/ConsoleInternal/style/_vars.scss
@@ -40,13 +40,13 @@ $table-border-color: $color-pf-black-200;
 
 // == Custom variables
 
-$co-m-label-line-height: 20px;
+$pfe-m-label-line-height: 20px;
 $pf-header-icon-fontsize: 16px; // Patternfly 4 default
 // Manually set because our default font size is different than PF 4
-$co-side-nav-font-size: $font-size-base; // Matches PF 4 --pf-c-nav__subnav__link--FontSize
-$co-side-nav-section-font-size: ($font-size-base + 2); // Matches PF 4 --pf-c-nav__link--FontSize
-$co-m-catalog-tile-height: 100%;
-$co-m-catalog-tile-width: 260px;
+$pfe-side-nav-font-size: $font-size-base; // Matches PF 4 --pf-c-nav__subnav__link--FontSize
+$pfe-side-nav-section-font-size: ($font-size-base + 2); // Matches PF 4 --pf-c-nav__link--FontSize
+$pfe-m-catalog-tile-height: 100%;
+$pfe-m-catalog-tile-width: 260px;
 
 
 // == Colors

--- a/packages/module/src/ConsoleInternal/style/_vars.scss
+++ b/packages/module/src/ConsoleInternal/style/_vars.scss
@@ -40,13 +40,13 @@ $table-border-color: $color-pf-black-200;
 
 // == Custom variables
 
-$pfe-m-label-line-height: 20px;
+$pfext-m-label-line-height: 20px;
 $pf-header-icon-fontsize: 16px; // Patternfly 4 default
 // Manually set because our default font size is different than PF 4
-$pfe-side-nav-font-size: $font-size-base; // Matches PF 4 --pf-c-nav__subnav__link--FontSize
-$pfe-side-nav-section-font-size: ($font-size-base + 2); // Matches PF 4 --pf-c-nav__link--FontSize
-$pfe-m-catalog-tile-height: 100%;
-$pfe-m-catalog-tile-width: 260px;
+$pfext-side-nav-font-size: $font-size-base; // Matches PF 4 --pf-c-nav__subnav__link--FontSize
+$pfext-side-nav-section-font-size: ($font-size-base + 2); // Matches PF 4 --pf-c-nav__link--FontSize
+$pfext-m-catalog-tile-height: 100%;
+$pfext-m-catalog-tile-width: 260px;
 
 
 // == Colors

--- a/packages/module/src/ConsoleInternal/style/mixin/_break-word.scss
+++ b/packages/module/src/ConsoleInternal/style/mixin/_break-word.scss
@@ -5,7 +5,7 @@
 // USAGE:
 // - DO choose to use this over `word-break: break-all` if at all possible, since break-all can break normal words in awkward places.
 
-@mixin pfe-break-word() {
+@mixin pfext-break-word() {
   min-width: 0; // required by FF and Edge
   overflow-wrap: break-word; // new name as per the CSS3 spec
   word-break: break-word; // required by FF and Edge

--- a/packages/module/src/ConsoleInternal/style/mixin/_break-word.scss
+++ b/packages/module/src/ConsoleInternal/style/mixin/_break-word.scss
@@ -5,7 +5,7 @@
 // USAGE:
 // - DO choose to use this over `word-break: break-all` if at all possible, since break-all can break normal words in awkward places.
 
-@mixin co-break-word() {
+@mixin pfe-break-word() {
   min-width: 0; // required by FF and Edge
   overflow-wrap: break-word; // new name as per the CSS3 spec
   word-break: break-word; // required by FF and Edge

--- a/packages/module/src/ConsoleInternal/vendor.scss
+++ b/packages/module/src/ConsoleInternal/vendor.scss
@@ -1,3 +1,5 @@
+@import '~@patternfly/patternfly/sass-utilities/all';
+
 @import '~@patternfly/react-catalog-view-extension/dist/sass/react-catalog-view-extension.scss';
 @import '~@patternfly/patternfly/components/ClipboardCopy/clipboard-copy.scss';
 @import '~@patternfly/patternfly/components/CodeBlock/code-block.scss';

--- a/packages/module/src/ConsoleInternal/vendor.scss
+++ b/packages/module/src/ConsoleInternal/vendor.scss
@@ -1,5 +1,3 @@
-.pfe-quick-start-panel-content {
-    @import '~@patternfly/react-catalog-view-extension/dist/sass/react-catalog-view-extension.scss';
-    @import '~@patternfly/patternfly/components/CodeBlock/code-block.scss';
-    @import '~@patternfly/patternfly/components/ClipboardCopy/clipboard-copy.scss';
-}
+@import '~@patternfly/react-catalog-view-extension/dist/sass/react-catalog-view-extension.scss';
+@import '~@patternfly/patternfly/components/ClipboardCopy/clipboard-copy.scss';
+@import '~@patternfly/patternfly/components/CodeBlock/code-block.scss';

--- a/packages/module/src/ConsoleInternal/vendor.scss
+++ b/packages/module/src/ConsoleInternal/vendor.scss
@@ -1,6 +1,5 @@
-@import 'style/vars';
-@import '~patternfly/dist/sass/patternfly/variables';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/variables';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/mixins';
-@import '~patternfly/dist/sass/patternfly/bootstrap-mixin-overrides';
-@import '~@patternfly/react-catalog-view-extension/dist/sass/react-catalog-view-extension.scss';
+.pfe-quick-start-panel-content {
+    @import '~@patternfly/react-catalog-view-extension/dist/sass/react-catalog-view-extension.scss';
+    @import '~@patternfly/patternfly/components/CodeBlock/code-block.scss';
+    @import '~@patternfly/patternfly/components/ClipboardCopy/clipboard-copy.scss';
+}

--- a/packages/module/src/ConsoleShared/src/components/layout/PageLayout.scss
+++ b/packages/module/src/ConsoleShared/src/components/layout/PageLayout.scss
@@ -1,4 +1,4 @@
-.ocs-page-layout {
+.pfext-page-layout {
   &__content {
     padding: var(--pf-global--spacer--lg);
     flex: 1;

--- a/packages/module/src/ConsoleShared/src/components/markdown-extensions/inline-clipboard-extension.tsx
+++ b/packages/module/src/ConsoleShared/src/components/markdown-extensions/inline-clipboard-extension.tsx
@@ -4,7 +4,6 @@ import { MARKDOWN_COPY_BUTTON_ID, MARKDOWN_SNIPPET_ID } from './const';
 import { removeTemplateWhitespace } from './utils';
 import { renderToStaticMarkup } from 'react-dom/server';
 import CopyIcon from '@patternfly/react-icons/dist/js/icons/copy-icon';
-import '@patternfly/react-styles/css/components/ClipboardCopy/clipboard-copy';
 import './showdown-extension.scss';
 
 const useInlineCopyClipboardShowdownExtension = () => {

--- a/packages/module/src/ConsoleShared/src/components/markdown-extensions/multiline-clipboard-extension.tsx
+++ b/packages/module/src/ConsoleShared/src/components/markdown-extensions/multiline-clipboard-extension.tsx
@@ -3,7 +3,6 @@ import { QuickStartContext, QuickStartContextValues } from '@quickstarts/utils/q
 import { MARKDOWN_COPY_BUTTON_ID, MARKDOWN_SNIPPET_ID } from './const';
 import { renderToStaticMarkup } from 'react-dom/server';
 import CopyIcon from '@patternfly/react-icons/dist/js/icons/copy-icon';
-import '@patternfly/react-styles/css/components/CodeBlock/code-block';
 
 import './showdown-extension.scss';
 

--- a/packages/module/src/ConsoleShared/src/components/markdown-extensions/multiline-clipboard-extension.tsx
+++ b/packages/module/src/ConsoleShared/src/components/markdown-extensions/multiline-clipboard-extension.tsx
@@ -35,7 +35,7 @@ const useMultilineCopyClipboardShowdownExtension = () => {
                 </div>
               </div>
               <div class="pf-c-code-block__content">
-                <pre class="pf-c-code-block__pre ocs-code-block__pre">
+                <pre class="pf-c-code-block__pre pfext-code-block__pre">
                   <code class="pf-c-code-block__code" 
                     ${MARKDOWN_SNIPPET_ID}="${groupType}">${group}</code>
                 </pre>

--- a/packages/module/src/ConsoleShared/src/components/markdown-extensions/showdown-extension.scss
+++ b/packages/module/src/ConsoleShared/src/components/markdown-extensions/showdown-extension.scss
@@ -1,4 +1,4 @@
-.co-markdown-view {
+.pfe-markdown-view {
   .ocs-code-block__pre {
     /* override the styles applied by showdown while parsing <pre /> */
     display: flex;

--- a/packages/module/src/ConsoleShared/src/components/markdown-extensions/showdown-extension.scss
+++ b/packages/module/src/ConsoleShared/src/components/markdown-extensions/showdown-extension.scss
@@ -1,4 +1,4 @@
-.pfe-markdown-view {
+.pfext-markdown-view {
   .ocs-code-block__pre {
     /* override the styles applied by showdown while parsing <pre /> */
     display: flex;

--- a/packages/module/src/ConsoleShared/src/components/markdown-extensions/showdown-extension.scss
+++ b/packages/module/src/ConsoleShared/src/components/markdown-extensions/showdown-extension.scss
@@ -1,5 +1,5 @@
 .pfext-markdown-view {
-  .ocs-code-block__pre {
+  .pfext-code-block__pre {
     /* override the styles applied by showdown while parsing <pre /> */
     display: flex;
     border: none;
@@ -9,7 +9,7 @@
     padding: 0;
   }
   
-  .ocs-markdown-execute-snippet {
+  .pfext-markdown-execute-snippet {
   
     &__button {
       & > i.fa-check {

--- a/packages/module/src/ConsoleShared/src/components/modal/Modal.scss
+++ b/packages/module/src/ConsoleShared/src/components/modal/Modal.scss
@@ -1,3 +1,3 @@
-.ocs-modal {
+.pfext-modal {
   position: absolute !important;
 }

--- a/packages/module/src/ConsoleShared/src/components/modal/Modal.tsx
+++ b/packages/module/src/ConsoleShared/src/components/modal/Modal.tsx
@@ -11,7 +11,7 @@ type ModalProps = {
 const Modal: React.FC<ModalProps> = ({ isFullScreen = false, className, ...props }) => (
   <PfModal
     {...props}
-    className={css('ocs-modal', className)}
+    className={css('pfext-modal', className)}
     appendTo={() => (isFullScreen ? document.body : document.querySelector('#modal-container'))}
   />
 );

--- a/packages/module/src/ConsoleShared/src/components/spotlight/InteractiveSpotlight.tsx
+++ b/packages/module/src/ConsoleShared/src/components/spotlight/InteractiveSpotlight.tsx
@@ -49,7 +49,7 @@ const InteractiveSpotlight: React.FC<InteractiveSpotlightProps> = ({ element }) 
   return (
     <Portal>
       <SimplePopper>
-        <div className="ocs-spotlight ocs-spotlight__element-highlight-animate" style={style} />
+        <div className="pfext-spotlight pfext-spotlight__element-highlight-animate" style={style} />
       </SimplePopper>
     </Portal>
   );

--- a/packages/module/src/ConsoleShared/src/components/spotlight/StaticSpotlight.tsx
+++ b/packages/module/src/ConsoleShared/src/components/spotlight/StaticSpotlight.tsx
@@ -19,8 +19,11 @@ const StaticSpotlight: React.FC<StaticSpotlightProps> = ({ element }) => {
     : {};
   return clientRect ? (
     <Portal>
-      <div className="pf-c-backdrop ocs-spotlight__with-backdrop">
-        <div className="ocs-spotlight ocs-spotlight__element-highlight-noanimate" style={style} />
+      <div className="pf-c-backdrop pfext-spotlight__with-backdrop">
+        <div
+          className="pfext-spotlight pfext-spotlight__element-highlight-noanimate"
+          style={style}
+        />
       </div>
     </Portal>
   ) : null;

--- a/packages/module/src/ConsoleShared/src/components/spotlight/spotlight.scss
+++ b/packages/module/src/ConsoleShared/src/components/spotlight/spotlight.scss
@@ -1,4 +1,4 @@
-@keyframes ocs-spotlight-expand {
+@keyframes pfext-spotlight-expand {
   0% {
     outline-offset: -4px;
     outline-width: 4px;
@@ -11,7 +11,7 @@
   }
 }
 
-@keyframes ocs-spotlight-fade-in {
+@keyframes pfext-spotlight-fade-in {
   0% {
     opacity: 0;
   }
@@ -20,7 +20,7 @@
   }
 }
 
-@keyframes ocs-spotlight-fade-out {
+@keyframes pfext-spotlight-fade-out {
   0% {
     opacity: 1;
   }
@@ -29,7 +29,7 @@
   }
 }
 
-.ocs-spotlight {
+.pfext-spotlight {
   pointer-events: none;
   position: absolute;
   &__with-backdrop {
@@ -45,7 +45,7 @@
     position: absolute;
     box-shadow: inset 0px 0px 0px 4px var(--pf-global--palette--blue-200);
     opacity: 0;
-    animation: 0.4s ocs-spotlight-fade-in 0s ease-in-out, 5s ocs-spotlight-fade-out 12.8s ease-in-out;
+    animation: 0.4s pfext-spotlight-fade-in 0s ease-in-out, 5s pfext-spotlight-fade-out 12.8s ease-in-out;
     animation-fill-mode: forwards;
     &::after {
       content: '';
@@ -54,7 +54,7 @@
       right: 0;
       top: 0;
       bottom: 0;
-      animation: 1.2s ocs-spotlight-expand 1.6s ease-out;
+      animation: 1.2s pfext-spotlight-expand 1.6s ease-out;
       animation-fill-mode: forwards;
       outline: 4px solid var(--pf-global--palette--blue-200);
       outline-offset: -4px;

--- a/packages/module/src/ConsoleShared/src/components/status/StatusIconAndText.tsx
+++ b/packages/module/src/ConsoleShared/src/components/status/StatusIconAndText.tsx
@@ -23,7 +23,7 @@ const StatusIconAndText: React.FC<StatusIconAndTextProps> = ({
 
   return (
     <span
-      className={css('pfe-icon-and-text', className)}
+      className={css('pfext-icon-and-text', className)}
       title={iconOnly && !noTooltip ? title : undefined}
     >
       {icon &&
@@ -31,7 +31,7 @@ const StatusIconAndText: React.FC<StatusIconAndTextProps> = ({
           className: css(
             spin && 'fa-spin',
             icon.props.className,
-            !iconOnly && 'pfe-icon-and-text__icon pfe-icon-flex-child',
+            !iconOnly && 'pfext-icon-and-text__icon pfext-icon-flex-child',
           ),
         })}
       {!iconOnly && <CamelCaseWrap value={title} dataTest="status-text" />}

--- a/packages/module/src/ConsoleShared/src/components/status/StatusIconAndText.tsx
+++ b/packages/module/src/ConsoleShared/src/components/status/StatusIconAndText.tsx
@@ -23,7 +23,7 @@ const StatusIconAndText: React.FC<StatusIconAndTextProps> = ({
 
   return (
     <span
-      className={css('co-icon-and-text', className)}
+      className={css('pfe-icon-and-text', className)}
       title={iconOnly && !noTooltip ? title : undefined}
     >
       {icon &&
@@ -31,7 +31,7 @@ const StatusIconAndText: React.FC<StatusIconAndTextProps> = ({
           className: css(
             spin && 'fa-spin',
             icon.props.className,
-            !iconOnly && 'co-icon-and-text__icon co-icon-flex-child',
+            !iconOnly && 'pfe-icon-and-text__icon pfe-icon-flex-child',
           ),
         })}
       {!iconOnly && <CamelCaseWrap value={title} dataTest="status-text" />}

--- a/packages/module/src/QuickStartCatalogPage.tsx
+++ b/packages/module/src/QuickStartCatalogPage.tsx
@@ -140,11 +140,11 @@ export const QuickStartCatalogPage: React.FC<QuickStartCatalogPageProps> = ({
   ) : (
     <>
       {showTitle && (
-        <div className="ocs-page-layout__header">
-          <Text component="h1" className="ocs-page-layout__title" data-test="page-title">
+        <div className="pfext-page-layout__header">
+          <Text component="h1" className="pfext-page-layout__title" data-test="page-title">
             {title || getResource('Quick Starts')}
           </Text>
-          {hint && <div className="ocs-page-layout__hint">{hint}</div>}
+          {hint && <div className="pfext-page-layout__hint">{hint}</div>}
         </div>
       )}
       {showTitle && <Divider component="div" />}

--- a/packages/module/src/QuickStartCloseModal.tsx
+++ b/packages/module/src/QuickStartCloseModal.tsx
@@ -17,7 +17,7 @@ const QuickStartCloseModal: React.FC<QuickStartCloseModalProps> = ({
   const { getResource } = React.useContext<QuickStartContextValues>(QuickStartContext);
   return (
     <Modal
-      className="co-quick-start-drawer__modal"
+      className="pfe-quick-start-drawer__modal"
       isOpen={isOpen}
       variant={ModalVariant.small}
       showClose={false}

--- a/packages/module/src/QuickStartCloseModal.tsx
+++ b/packages/module/src/QuickStartCloseModal.tsx
@@ -17,7 +17,7 @@ const QuickStartCloseModal: React.FC<QuickStartCloseModalProps> = ({
   const { getResource } = React.useContext<QuickStartContextValues>(QuickStartContext);
   return (
     <Modal
-      className="pfe-quick-start-drawer__modal"
+      className="pfext-quick-start-drawer__modal"
       isOpen={isOpen}
       variant={ModalVariant.small}
       showClose={false}

--- a/packages/module/src/QuickStartDrawer.scss
+++ b/packages/module/src/QuickStartDrawer.scss
@@ -1,4 +1,4 @@
-.co-quick-start-drawer {
+.pfe-quick-start-drawer {
   &__body {
     display: flex;
     flex-direction: column;

--- a/packages/module/src/QuickStartDrawer.scss
+++ b/packages/module/src/QuickStartDrawer.scss
@@ -1,4 +1,4 @@
-.pfe-quick-start-drawer {
+.pfext-quick-start-drawer {
   &__body {
     display: flex;
     flex-direction: column;

--- a/packages/module/src/QuickStartDrawer.tsx
+++ b/packages/module/src/QuickStartDrawer.tsx
@@ -107,7 +107,7 @@ export const QuickStartDrawer: React.FC<QuickStartDrawerProps> = ({
       <Drawer isExpanded={!!activeQuickStartID} isInline isStatic={isStatic} {...props}>
         {children ? (
           <DrawerContent panelContent={panelContent} {...fullWidthBodyStyle}>
-            <DrawerContentBody className="co-quick-start-drawer__body">
+            <DrawerContentBody className="pfe-quick-start-drawer__body">
               {children}
             </DrawerContentBody>
           </DrawerContent>

--- a/packages/module/src/QuickStartDrawer.tsx
+++ b/packages/module/src/QuickStartDrawer.tsx
@@ -107,7 +107,7 @@ export const QuickStartDrawer: React.FC<QuickStartDrawerProps> = ({
       <Drawer isExpanded={!!activeQuickStartID} isInline isStatic={isStatic} {...props}>
         {children ? (
           <DrawerContent panelContent={panelContent} {...fullWidthBodyStyle}>
-            <DrawerContentBody className="pfe-quick-start-drawer__body">
+            <DrawerContentBody className="pfext-quick-start-drawer__body">
               {children}
             </DrawerContentBody>
           </DrawerContent>

--- a/packages/module/src/QuickStartPanelContent.scss
+++ b/packages/module/src/QuickStartPanelContent.scss
@@ -1,4 +1,4 @@
-.pfe-quick-start-panel-content {
+.pfext-quick-start-panel-content {
   &__header {
     position: sticky;
     top: 0px;

--- a/packages/module/src/QuickStartPanelContent.scss
+++ b/packages/module/src/QuickStartPanelContent.scss
@@ -1,4 +1,4 @@
-.co-quick-start-panel-content {
+.pfe-quick-start-panel-content {
   &__header {
     position: sticky;
     top: 0px;

--- a/packages/module/src/QuickStartPanelContent.tsx
+++ b/packages/module/src/QuickStartPanelContent.tsx
@@ -53,13 +53,13 @@ const QuickStartPanelContent: React.FC<QuickStartPanelContentProps> = ({
     quickStart?.spec.nextQuickStart?.includes(qs.metadata.name),
   );
 
-  const headerClasses = css('co-quick-start-panel-content__header', {
-    'co-quick-start-panel-content__header__shadow':
+  const headerClasses = css('pfe-quick-start-panel-content__header', {
+    'pfe-quick-start-panel-content__header__shadow':
       shadows === Shadows.top || shadows === Shadows.both,
   });
 
   const footerClass = css({
-    'co-quick-start-panel-content__footer__shadow':
+    'pfe-quick-start-panel-content__footer__shadow':
       shadows === Shadows.bottom || shadows === Shadows.both,
   });
 
@@ -77,7 +77,7 @@ const QuickStartPanelContent: React.FC<QuickStartPanelContentProps> = ({
   const content = quickStart ? (
     <DrawerPanelContent
       isResizable={isResizable}
-      className="co-quick-start-panel-content"
+      className="pfe-quick-start-panel-content"
       data-testid={`qs-drawer-${camelize(quickStart.spec.displayName)}`}
       data-qs={`qs-step-${getStep()}`}
       data-test="quickstart drawer"
@@ -85,14 +85,14 @@ const QuickStartPanelContent: React.FC<QuickStartPanelContentProps> = ({
     >
       <div className={headerClasses}>
         <DrawerHead>
-          <div className="co-quick-start-panel-content__title">
+          <div className="pfe-quick-start-panel-content__title">
             <Title
               headingLevel="h1"
               size="xl"
               style={{ marginRight: 'var(--pf-global--spacer--md)' }}
             >
               {quickStart?.spec.displayName}{' '}
-              <small className="co-quick-start-panel-content__duration text-secondary">
+              <small className="pfe-quick-start-panel-content__duration text-secondary">
                 {getResource(
                   '{{duration, number}} minutes',
                   quickStart?.spec.durationMinutes,
@@ -109,7 +109,7 @@ const QuickStartPanelContent: React.FC<QuickStartPanelContentProps> = ({
       </div>
       <DrawerPanelBody
         hasNoPadding
-        className="co-quick-start-panel-content__body"
+        className="pfe-quick-start-panel-content__body"
         data-test="content"
       >
         <QuickStartController

--- a/packages/module/src/QuickStartPanelContent.tsx
+++ b/packages/module/src/QuickStartPanelContent.tsx
@@ -53,13 +53,13 @@ const QuickStartPanelContent: React.FC<QuickStartPanelContentProps> = ({
     quickStart?.spec.nextQuickStart?.includes(qs.metadata.name),
   );
 
-  const headerClasses = css('pfe-quick-start-panel-content__header', {
-    'pfe-quick-start-panel-content__header__shadow':
+  const headerClasses = css('pfext-quick-start-panel-content__header', {
+    'pfext-quick-start-panel-content__header__shadow':
       shadows === Shadows.top || shadows === Shadows.both,
   });
 
   const footerClass = css({
-    'pfe-quick-start-panel-content__footer__shadow':
+    'pfext-quick-start-panel-content__footer__shadow':
       shadows === Shadows.bottom || shadows === Shadows.both,
   });
 
@@ -77,7 +77,7 @@ const QuickStartPanelContent: React.FC<QuickStartPanelContentProps> = ({
   const content = quickStart ? (
     <DrawerPanelContent
       isResizable={isResizable}
-      className="pfe-quick-start-panel-content"
+      className="pfext-quick-start-panel-content"
       data-testid={`qs-drawer-${camelize(quickStart.spec.displayName)}`}
       data-qs={`qs-step-${getStep()}`}
       data-test="quickstart drawer"
@@ -85,14 +85,14 @@ const QuickStartPanelContent: React.FC<QuickStartPanelContentProps> = ({
     >
       <div className={headerClasses}>
         <DrawerHead>
-          <div className="pfe-quick-start-panel-content__title">
+          <div className="pfext-quick-start-panel-content__title">
             <Title
               headingLevel="h1"
               size="xl"
               style={{ marginRight: 'var(--pf-global--spacer--md)' }}
             >
               {quickStart?.spec.displayName}{' '}
-              <small className="pfe-quick-start-panel-content__duration text-secondary">
+              <small className="pfext-quick-start-panel-content__duration text-secondary">
                 {getResource(
                   '{{duration, number}} minutes',
                   quickStart?.spec.durationMinutes,
@@ -109,7 +109,7 @@ const QuickStartPanelContent: React.FC<QuickStartPanelContentProps> = ({
       </div>
       <DrawerPanelBody
         hasNoPadding
-        className="pfe-quick-start-panel-content__body"
+        className="pfext-quick-start-panel-content__body"
         data-test="content"
       >
         <QuickStartController

--- a/packages/module/src/catalog/Catalog/QuickStartCatalogHeader.tsx
+++ b/packages/module/src/catalog/Catalog/QuickStartCatalogHeader.tsx
@@ -9,10 +9,10 @@ export const QuickStartCatalogHeader: React.FC<QuickStartCatalogHeaderProps> = (
   title,
   hint,
 }) => (
-  <div className="ocs-page-layout__header">
-    <h1 data-pf-content="true" className="ocs-page-layout__title">
+  <div className="pfext-page-layout__header">
+    <h1 data-pf-content="true" className="pfext-page-layout__title">
       {title}
     </h1>
-    {hint && <div className="ocs-page-layout__hint">{hint}</div>}
+    {hint && <div className="pfext-page-layout__hint">{hint}</div>}
   </div>
 );

--- a/packages/module/src/catalog/Catalog/QuickStartCatalogSection.tsx
+++ b/packages/module/src/catalog/Catalog/QuickStartCatalogSection.tsx
@@ -5,5 +5,5 @@ export type QuickStartCatalogSectionProps = {
 };
 
 export const QuickStartCatalogSection: React.FC<QuickStartCatalogSectionProps> = ({ children }) => (
-  <div className="ocs-page-layout__content is-dark">{children}</div>
+  <div className="pfext-page-layout__content is-dark">{children}</div>
 );

--- a/packages/module/src/catalog/Catalog/QuickStartCatalogToolbar.tsx
+++ b/packages/module/src/catalog/Catalog/QuickStartCatalogToolbar.tsx
@@ -6,7 +6,7 @@ export type QuickStartCatalogToolbarProps = {
 };
 
 export const QuickStartCatalogToolbar: React.FC<QuickStartCatalogToolbarProps> = ({ children }) => (
-  <Toolbar usePageInsets className="co-quick-start-catalog-filter__flex">
+  <Toolbar usePageInsets className="pfe-quick-start-catalog-filter__flex">
     {children}
   </Toolbar>
 );

--- a/packages/module/src/catalog/Catalog/QuickStartCatalogToolbar.tsx
+++ b/packages/module/src/catalog/Catalog/QuickStartCatalogToolbar.tsx
@@ -6,7 +6,7 @@ export type QuickStartCatalogToolbarProps = {
 };
 
 export const QuickStartCatalogToolbar: React.FC<QuickStartCatalogToolbarProps> = ({ children }) => (
-  <Toolbar usePageInsets className="pfe-quick-start-catalog-filter__flex">
+  <Toolbar usePageInsets className="pfext-quick-start-catalog-filter__flex">
     {children}
   </Toolbar>
 );

--- a/packages/module/src/catalog/QuickStartCatalog.scss
+++ b/packages/module/src/catalog/QuickStartCatalog.scss
@@ -1,4 +1,4 @@
-.co-quick-start-catalog {
+.pfe-quick-start-catalog {
   &__gallery {
     --pf-l-gallery--GridTemplateColumns: repeat(auto-fill, 300px) !important;
   }

--- a/packages/module/src/catalog/QuickStartCatalog.scss
+++ b/packages/module/src/catalog/QuickStartCatalog.scss
@@ -1,4 +1,4 @@
-.pfe-quick-start-catalog {
+.pfext-quick-start-catalog {
   &__gallery {
     --pf-l-gallery--GridTemplateColumns: repeat(auto-fill, 300px) !important;
   }

--- a/packages/module/src/catalog/QuickStartCatalog.tsx
+++ b/packages/module/src/catalog/QuickStartCatalog.tsx
@@ -18,14 +18,14 @@ const QuickStartCatalog: React.FC<QuickStartCatalogProps> = ({ quickStarts }) =>
 
   return (
     <div className="ocs-page-layout__content is-dark">
-      <Gallery className="pfe-quick-start-catalog__gallery" hasGutter>
+      <Gallery className="pfext-quick-start-catalog__gallery" hasGutter>
         {quickStarts.map((quickStart) => {
           const {
             metadata: { name: id },
           } = quickStart;
 
           return (
-            <GalleryItem key={id} className="pfe-quick-start-catalog__gallery-item">
+            <GalleryItem key={id} className="pfext-quick-start-catalog__gallery-item">
               <QuickStartTile
                 quickStart={quickStart}
                 isActive={id === activeQuickStartID}

--- a/packages/module/src/catalog/QuickStartCatalog.tsx
+++ b/packages/module/src/catalog/QuickStartCatalog.tsx
@@ -17,7 +17,7 @@ const QuickStartCatalog: React.FC<QuickStartCatalogProps> = ({ quickStarts }) =>
   );
 
   return (
-    <div className="ocs-page-layout__content is-dark">
+    <div className="pfext-page-layout__content is-dark">
       <Gallery className="pfext-quick-start-catalog__gallery" hasGutter>
         {quickStarts.map((quickStart) => {
           const {

--- a/packages/module/src/catalog/QuickStartCatalog.tsx
+++ b/packages/module/src/catalog/QuickStartCatalog.tsx
@@ -18,14 +18,14 @@ const QuickStartCatalog: React.FC<QuickStartCatalogProps> = ({ quickStarts }) =>
 
   return (
     <div className="ocs-page-layout__content is-dark">
-      <Gallery className="co-quick-start-catalog__gallery" hasGutter>
+      <Gallery className="pfe-quick-start-catalog__gallery" hasGutter>
         {quickStarts.map((quickStart) => {
           const {
             metadata: { name: id },
           } = quickStart;
 
           return (
-            <GalleryItem key={id} className="co-quick-start-catalog__gallery-item">
+            <GalleryItem key={id} className="pfe-quick-start-catalog__gallery-item">
               <QuickStartTile
                 quickStart={quickStart}
                 isActive={id === activeQuickStartID}

--- a/packages/module/src/catalog/QuickStartTile.scss
+++ b/packages/module/src/catalog/QuickStartTile.scss
@@ -1,4 +1,4 @@
-.pfe-quick-start-tile {
+.pfext-quick-start-tile {
   height: 100%;
   & .catalog-tile-pf-description .has-footer {
     display: block;

--- a/packages/module/src/catalog/QuickStartTile.scss
+++ b/packages/module/src/catalog/QuickStartTile.scss
@@ -1,4 +1,4 @@
-.co-quick-start-tile {
+.pfe-quick-start-tile {
   height: 100%;
   & .catalog-tile-pf-description .has-footer {
     display: block;

--- a/packages/module/src/catalog/QuickStartTile.tsx
+++ b/packages/module/src/catalog/QuickStartTile.tsx
@@ -38,7 +38,7 @@ const QuickStartTile: React.FC<QuickStartTileProps> = ({
 
   const quickStartIcon = (
     <FallbackImg
-      className="co-catalog-item-icon__img--large"
+      className="pfe-catalog-item-icon__img--large"
       src={icon}
       alt=""
       fallback={<RocketIcon />}
@@ -72,7 +72,7 @@ const QuickStartTile: React.FC<QuickStartTileProps> = ({
           cursor: 'pointer',
         }}
         icon={quickStartIcon}
-        className="co-quick-start-tile"
+        className="pfe-quick-start-tile"
         data-testid={`qs-card-${camelize(displayName)}`}
         featured={isActive}
         title={

--- a/packages/module/src/catalog/QuickStartTile.tsx
+++ b/packages/module/src/catalog/QuickStartTile.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { CatalogTile } from '@patternfly/react-catalog-view-extension';
+// import { CatalogTile } from '@patternfly/react-catalog-view-extension';
+import { CatalogTile } from '../react-catalog-view-extension/CatalogTile';
 import RocketIcon from '@patternfly/react-icons/dist/js/icons/rocket-icon';
 import { FallbackImg } from '@console/shared';
 import { QuickStartContext, QuickStartContextValues } from '../utils/quick-start-context';
@@ -38,7 +39,7 @@ const QuickStartTile: React.FC<QuickStartTileProps> = ({
 
   const quickStartIcon = (
     <FallbackImg
-      className="pfe-catalog-item-icon__img--large"
+      className="pfext-catalog-item-icon__img--large"
       src={icon}
       alt=""
       fallback={<RocketIcon />}
@@ -72,7 +73,7 @@ const QuickStartTile: React.FC<QuickStartTileProps> = ({
           cursor: 'pointer',
         }}
         icon={quickStartIcon}
-        className="pfe-quick-start-tile"
+        className="pfext-quick-start-tile"
         data-testid={`qs-card-${camelize(displayName)}`}
         featured={isActive}
         title={

--- a/packages/module/src/catalog/QuickStartTileDescription.scss
+++ b/packages/module/src/catalog/QuickStartTileDescription.scss
@@ -1,4 +1,4 @@
-.co-quick-start-tile {
+.pfe-quick-start-tile {
   &-description {
     display: -webkit-box;
     overflow: hidden;

--- a/packages/module/src/catalog/QuickStartTileDescription.scss
+++ b/packages/module/src/catalog/QuickStartTileDescription.scss
@@ -1,4 +1,4 @@
-.pfe-quick-start-tile {
+.pfext-quick-start-tile {
   &-description {
     display: -webkit-box;
     overflow: hidden;

--- a/packages/module/src/catalog/QuickStartTileDescription.tsx
+++ b/packages/module/src/catalog/QuickStartTileDescription.tsx
@@ -25,7 +25,10 @@ const QuickStartTileDescription: React.FC<QuickStartTileDescriptionProps> = ({
   const prereqs = prerequisites?.filter((p) => p);
   return (
     <>
-      <QuickStartMarkdownView content={description} className="pfext-quick-start-tile-description" />
+      <QuickStartMarkdownView
+        content={description}
+        className="pfext-quick-start-tile-description"
+      />
       {prereqs?.length > 0 && (
         <div className="pfext-quick-start-tile-prerequisites">
           <Text component={TextVariants.h5} className="pfext-quick-start-tile-prerequisites__text">
@@ -37,7 +40,7 @@ const QuickStartTileDescription: React.FC<QuickStartTileDescriptionProps> = ({
           <Popover
             aria-label={getResource('Prerequisites')}
             headerContent={getResource('Prerequisites')}
-            className="ocs-page-layout__base"
+            className="pfext-page-layout__base"
             bodyContent={
               <TextList
                 aria-label={getResource('Prerequisites')}

--- a/packages/module/src/catalog/QuickStartTileDescription.tsx
+++ b/packages/module/src/catalog/QuickStartTileDescription.tsx
@@ -25,10 +25,10 @@ const QuickStartTileDescription: React.FC<QuickStartTileDescriptionProps> = ({
   const prereqs = prerequisites?.filter((p) => p);
   return (
     <>
-      <QuickStartMarkdownView content={description} className="pfe-quick-start-tile-description" />
+      <QuickStartMarkdownView content={description} className="pfext-quick-start-tile-description" />
       {prereqs?.length > 0 && (
-        <div className="pfe-quick-start-tile-prerequisites">
-          <Text component={TextVariants.h5} className="pfe-quick-start-tile-prerequisites__text">
+        <div className="pfext-quick-start-tile-prerequisites">
+          <Text component={TextVariants.h5} className="pfext-quick-start-tile-prerequisites__text">
             {getResource('Prerequisites ({{totalPrereqs}})').replace(
               '{{totalPrereqs}}',
               prereqs.length,
@@ -41,7 +41,7 @@ const QuickStartTileDescription: React.FC<QuickStartTileDescriptionProps> = ({
             bodyContent={
               <TextList
                 aria-label={getResource('Prerequisites')}
-                className="pfe-quick-start-tile-prerequisites-list"
+                className="pfext-quick-start-tile-prerequisites-list"
               >
                 {prereqs.map((prerequisite, index) => (
                   // eslint-disable-next-line react/no-array-index-key
@@ -55,7 +55,7 @@ const QuickStartTileDescription: React.FC<QuickStartTileDescriptionProps> = ({
             <Button
               variant="link"
               isInline
-              className="pfe-quick-start-tile-prerequisites__icon"
+              className="pfext-quick-start-tile-prerequisites__icon"
               data-testid="qs-card-prereqs"
               onClick={(e) => {
                 e.preventDefault();

--- a/packages/module/src/catalog/QuickStartTileDescription.tsx
+++ b/packages/module/src/catalog/QuickStartTileDescription.tsx
@@ -25,10 +25,10 @@ const QuickStartTileDescription: React.FC<QuickStartTileDescriptionProps> = ({
   const prereqs = prerequisites?.filter((p) => p);
   return (
     <>
-      <QuickStartMarkdownView content={description} className="co-quick-start-tile-description" />
+      <QuickStartMarkdownView content={description} className="pfe-quick-start-tile-description" />
       {prereqs?.length > 0 && (
-        <div className="co-quick-start-tile-prerequisites">
-          <Text component={TextVariants.h5} className="co-quick-start-tile-prerequisites__text">
+        <div className="pfe-quick-start-tile-prerequisites">
+          <Text component={TextVariants.h5} className="pfe-quick-start-tile-prerequisites__text">
             {getResource('Prerequisites ({{totalPrereqs}})').replace(
               '{{totalPrereqs}}',
               prereqs.length,
@@ -41,7 +41,7 @@ const QuickStartTileDescription: React.FC<QuickStartTileDescriptionProps> = ({
             bodyContent={
               <TextList
                 aria-label={getResource('Prerequisites')}
-                className="co-quick-start-tile-prerequisites-list"
+                className="pfe-quick-start-tile-prerequisites-list"
               >
                 {prereqs.map((prerequisite, index) => (
                   // eslint-disable-next-line react/no-array-index-key
@@ -55,7 +55,7 @@ const QuickStartTileDescription: React.FC<QuickStartTileDescriptionProps> = ({
             <Button
               variant="link"
               isInline
-              className="co-quick-start-tile-prerequisites__icon"
+              className="pfe-quick-start-tile-prerequisites__icon"
               data-testid="qs-card-prereqs"
               onClick={(e) => {
                 e.preventDefault();

--- a/packages/module/src/catalog/QuickStartTileHeader.scss
+++ b/packages/module/src/catalog/QuickStartTileHeader.scss
@@ -1,4 +1,4 @@
-.co-quick-start-tile-header {
+.pfe-quick-start-tile-header {
   &__status {
     margin: var(--pf-global--spacer--sm) 0;
   }

--- a/packages/module/src/catalog/QuickStartTileHeader.scss
+++ b/packages/module/src/catalog/QuickStartTileHeader.scss
@@ -1,4 +1,4 @@
-.pfe-quick-start-tile-header {
+.pfext-quick-start-tile-header {
   &__status {
     margin: var(--pf-global--spacer--sm) 0;
   }

--- a/packages/module/src/catalog/QuickStartTileHeader.tsx
+++ b/packages/module/src/catalog/QuickStartTileHeader.tsx
@@ -34,13 +34,13 @@ const QuickStartTileHeader: React.FC<QuickStartTileHeaderProps> = ({
   };
 
   return (
-    <div className="pfe-quick-start-tile-header">
+    <div className="pfext-quick-start-tile-header">
       <Title headingLevel="h3" data-test="title">
         {name}
       </Title>
-      <div className="pfe-quick-start-tile-header__status">
+      <div className="pfext-quick-start-tile-header__status">
         {type && (
-          <Label className="pfe-quick-start-tile-header--margin" color={type.color}>
+          <Label className="pfext-quick-start-tile-header--margin" color={type.color}>
             {type.text}
           </Label>
         )}
@@ -49,7 +49,7 @@ const QuickStartTileHeader: React.FC<QuickStartTileHeaderProps> = ({
             variant="outline"
             data-test="duration"
             icon={<OutlinedClockIcon />}
-            className="pfe-quick-start-tile-header--margin"
+            className="pfext-quick-start-tile-header--margin"
           >
             {getResource('{{duration, number}} minutes', duration).replace(
               '{{duration, number}}',

--- a/packages/module/src/catalog/QuickStartTileHeader.tsx
+++ b/packages/module/src/catalog/QuickStartTileHeader.tsx
@@ -34,13 +34,13 @@ const QuickStartTileHeader: React.FC<QuickStartTileHeaderProps> = ({
   };
 
   return (
-    <div className="co-quick-start-tile-header">
+    <div className="pfe-quick-start-tile-header">
       <Title headingLevel="h3" data-test="title">
         {name}
       </Title>
-      <div className="co-quick-start-tile-header__status">
+      <div className="pfe-quick-start-tile-header__status">
         {type && (
-          <Label className="co-quick-start-tile-header--margin" color={type.color}>
+          <Label className="pfe-quick-start-tile-header--margin" color={type.color}>
             {type.text}
           </Label>
         )}
@@ -49,7 +49,7 @@ const QuickStartTileHeader: React.FC<QuickStartTileHeaderProps> = ({
             variant="outline"
             data-test="duration"
             icon={<OutlinedClockIcon />}
-            className="co-quick-start-tile-header--margin"
+            className="pfe-quick-start-tile-header--margin"
           >
             {getResource('{{duration, number}} minutes', duration).replace(
               '{{duration, number}}',

--- a/packages/module/src/catalog/Toolbar/QuickStartCatalogFilter.scss
+++ b/packages/module/src/catalog/Toolbar/QuickStartCatalogFilter.scss
@@ -1,4 +1,4 @@
-.co-quick-start-catalog-filter {
+.pfe-quick-start-catalog-filter {
   &__input {
     flex-grow: 1;
     max-width: 500px;
@@ -9,7 +9,7 @@
   }
 }
 
-.pf-c-toolbar.pf-m-page-insets.co-quick-start-catalog-filter__flex {
+.pf-c-toolbar.pf-m-page-insets.pfe-quick-start-catalog-filter__flex {
   --pf-c-toolbar--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-toolbar--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-toolbar--RowGap: 0;

--- a/packages/module/src/catalog/Toolbar/QuickStartCatalogFilter.scss
+++ b/packages/module/src/catalog/Toolbar/QuickStartCatalogFilter.scss
@@ -1,4 +1,4 @@
-.pfe-quick-start-catalog-filter {
+.pfext-quick-start-catalog-filter {
   &__input {
     flex-grow: 1;
     max-width: 500px;
@@ -9,7 +9,7 @@
   }
 }
 
-.pf-c-toolbar.pf-m-page-insets.pfe-quick-start-catalog-filter__flex {
+.pf-c-toolbar.pf-m-page-insets.pfext-quick-start-catalog-filter__flex {
   --pf-c-toolbar--PaddingBottom: var(--pf-global--spacer--sm);
   --pf-c-toolbar--PaddingTop: var(--pf-global--spacer--sm);
   --pf-c-toolbar--RowGap: 0;

--- a/packages/module/src/catalog/Toolbar/QuickStartCatalogFilter.tsx
+++ b/packages/module/src/catalog/Toolbar/QuickStartCatalogFilter.tsx
@@ -21,7 +21,7 @@ const QuickStartCatalogFilter: React.FC<QuickStartCatalogFilterProps> = ({
   ...props
 }) => {
   return (
-    <Toolbar usePageInsets className="pfe-quick-start-catalog-filter__flex" {...props}>
+    <Toolbar usePageInsets className="pfext-quick-start-catalog-filter__flex" {...props}>
       <ToolbarContent>
         <QuickStartCatalogFilterSearchWrapper onSearchInputChange={onSearchInputChange} />
         <QuickStartCatalogFilterStatusWrapper onStatusChange={onStatusChange} />

--- a/packages/module/src/catalog/Toolbar/QuickStartCatalogFilter.tsx
+++ b/packages/module/src/catalog/Toolbar/QuickStartCatalogFilter.tsx
@@ -21,7 +21,7 @@ const QuickStartCatalogFilter: React.FC<QuickStartCatalogFilterProps> = ({
   ...props
 }) => {
   return (
-    <Toolbar usePageInsets className="co-quick-start-catalog-filter__flex" {...props}>
+    <Toolbar usePageInsets className="pfe-quick-start-catalog-filter__flex" {...props}>
       <ToolbarContent>
         <QuickStartCatalogFilterSearchWrapper onSearchInputChange={onSearchInputChange} />
         <QuickStartCatalogFilterStatusWrapper onStatusChange={onStatusChange} />

--- a/packages/module/src/catalog/Toolbar/QuickStartCatalogFilterItems.tsx
+++ b/packages/module/src/catalog/Toolbar/QuickStartCatalogFilterItems.tsx
@@ -14,7 +14,7 @@ import { QuickStartContext, QuickStartContextValues } from '../../utils/quick-st
 export const QuickStartCatalogFilterSearch = ({ searchInputText, handleTextChange, ...props }) => {
   const { getResource } = React.useContext<QuickStartContextValues>(QuickStartContext);
   return (
-    <ToolbarItem className="pfe-quick-start-catalog-filter__input">
+    <ToolbarItem className="pfext-quick-start-catalog-filter__input">
       <SearchInput
         placeholder={getResource('Filter by keyword...')}
         value={searchInputText}
@@ -57,7 +57,7 @@ export const QuickStartCatalogFilterCount = ({ quickStartsCount }) => {
   const { getResource } = React.useContext<QuickStartContextValues>(QuickStartContext);
   return (
     <ToolbarItem
-      className="pfe-quick-start-catalog-filter__count"
+      className="pfext-quick-start-catalog-filter__count"
       alignment={{ default: 'alignRight' }}
     >
       {getResource('{{count, number}} item', quickStartsCount).replace(

--- a/packages/module/src/catalog/Toolbar/QuickStartCatalogFilterItems.tsx
+++ b/packages/module/src/catalog/Toolbar/QuickStartCatalogFilterItems.tsx
@@ -14,7 +14,7 @@ import { QuickStartContext, QuickStartContextValues } from '../../utils/quick-st
 export const QuickStartCatalogFilterSearch = ({ searchInputText, handleTextChange, ...props }) => {
   const { getResource } = React.useContext<QuickStartContextValues>(QuickStartContext);
   return (
-    <ToolbarItem className="co-quick-start-catalog-filter__input">
+    <ToolbarItem className="pfe-quick-start-catalog-filter__input">
       <SearchInput
         placeholder={getResource('Filter by keyword...')}
         value={searchInputText}
@@ -57,7 +57,7 @@ export const QuickStartCatalogFilterCount = ({ quickStartsCount }) => {
   const { getResource } = React.useContext<QuickStartContextValues>(QuickStartContext);
   return (
     <ToolbarItem
-      className="co-quick-start-catalog-filter__count"
+      className="pfe-quick-start-catalog-filter__count"
       alignment={{ default: 'alignRight' }}
     >
       {getResource('{{count, number}} item', quickStartsCount).replace(

--- a/packages/module/src/catalog/__tests__/QuickStartTile.spec.tsx
+++ b/packages/module/src/catalog/__tests__/QuickStartTile.spec.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { CatalogTile } from '@patternfly/react-catalog-view-extension';
+// import { CatalogTile } from '@patternfly/react-catalog-view-extension';
+import { CatalogTile } from '../../react-catalog-view-extension/CatalogTile';
 import { shallow } from 'enzyme';
 import { getQuickStarts } from '../../data/test-utils';
 import { QuickStartStatus } from '../../utils/quick-start-types';

--- a/packages/module/src/controller/QuickStartContent.scss
+++ b/packages/module/src/controller/QuickStartContent.scss
@@ -1,6 +1,6 @@
 @import '~bootstrap-sass/assets/stylesheets/bootstrap/variables';
 
-.pfe-quick-start-content {
+.pfext-quick-start-content {
   flex: 1 1 0;
   overflow: auto;
   padding: var(--pf-global--spacer--sm) var(--pf-global--spacer--lg);

--- a/packages/module/src/controller/QuickStartContent.scss
+++ b/packages/module/src/controller/QuickStartContent.scss
@@ -1,6 +1,6 @@
 @import '~bootstrap-sass/assets/stylesheets/bootstrap/variables';
 
-.co-quick-start-content {
+.pfe-quick-start-content {
   flex: 1 1 0;
   overflow: auto;
   padding: var(--pf-global--spacer--sm) var(--pf-global--spacer--lg);

--- a/packages/module/src/controller/QuickStartContent.tsx
+++ b/packages/module/src/controller/QuickStartContent.tsx
@@ -36,7 +36,7 @@ const QuickStartContent = React.forwardRef<HTMLDivElement, QuickStartContentProp
     const nextQS = nextQuickStarts.length > 0 && nextQuickStarts[0];
 
     return (
-      <div className="co-quick-start-content" ref={ref}>
+      <div className="pfe-quick-start-content" ref={ref}>
         {taskNumber === -1 && (
           <QuickStartIntroduction
             tasks={tasks}

--- a/packages/module/src/controller/QuickStartContent.tsx
+++ b/packages/module/src/controller/QuickStartContent.tsx
@@ -36,7 +36,7 @@ const QuickStartContent = React.forwardRef<HTMLDivElement, QuickStartContentProp
     const nextQS = nextQuickStarts.length > 0 && nextQuickStarts[0];
 
     return (
-      <div className="pfe-quick-start-content" ref={ref}>
+      <div className="pfext-quick-start-content" ref={ref}>
         {taskNumber === -1 && (
           <QuickStartIntroduction
             tasks={tasks}

--- a/packages/module/src/controller/QuickStartFooter.scss
+++ b/packages/module/src/controller/QuickStartFooter.scss
@@ -1,4 +1,4 @@
-.pfe-quick-start-footer {
+.pfext-quick-start-footer {
   background-color: var(--pf-global--Color--light-100);
   flex: 0 0 auto;
   padding: var(--pf-global--spacer--md) var(--pf-global--spacer--lg);

--- a/packages/module/src/controller/QuickStartFooter.scss
+++ b/packages/module/src/controller/QuickStartFooter.scss
@@ -1,4 +1,4 @@
-.co-quick-start-footer {
+.pfe-quick-start-footer {
   background-color: var(--pf-global--Color--light-100);
   flex: 0 0 auto;
   padding: var(--pf-global--spacer--md) var(--pf-global--spacer--lg);

--- a/packages/module/src/controller/QuickStartFooter.tsx
+++ b/packages/module/src/controller/QuickStartFooter.tsx
@@ -74,7 +74,7 @@ const QuickStartFooter: React.FC<QuickStartFooterProps> = ({
     () => (
       <Button
         variant="primary"
-        className="pfe-quick-start-footer__actionbtn"
+        className="pfext-quick-start-footer__actionbtn"
         onClick={onNext}
         data-testid={`qs-drawer-${camelize(getPrimaryButtonText)}`}
         data-test={`${getPrimaryButtonText} button`}
@@ -107,7 +107,7 @@ const QuickStartFooter: React.FC<QuickStartFooterProps> = ({
       taskNumber === totalTasks && (
         <Button
           variant="link"
-          className="pfe-quick-start-footer__restartbtn"
+          className="pfext-quick-start-footer__restartbtn"
           onClick={onRestart}
           data-testid="qs-drawer-side-note-action"
         >
@@ -118,7 +118,7 @@ const QuickStartFooter: React.FC<QuickStartFooterProps> = ({
   );
 
   return (
-    <div className={`pfe-quick-start-footer ${footerClass}`}>
+    <div className={`pfext-quick-start-footer ${footerClass}`}>
       {getPrimaryButton}
       {getSecondaryButton}
       {getSideNoteAction}

--- a/packages/module/src/controller/QuickStartFooter.tsx
+++ b/packages/module/src/controller/QuickStartFooter.tsx
@@ -74,7 +74,7 @@ const QuickStartFooter: React.FC<QuickStartFooterProps> = ({
     () => (
       <Button
         variant="primary"
-        className="co-quick-start-footer__actionbtn"
+        className="pfe-quick-start-footer__actionbtn"
         onClick={onNext}
         data-testid={`qs-drawer-${camelize(getPrimaryButtonText)}`}
         data-test={`${getPrimaryButtonText} button`}
@@ -107,7 +107,7 @@ const QuickStartFooter: React.FC<QuickStartFooterProps> = ({
       taskNumber === totalTasks && (
         <Button
           variant="link"
-          className="co-quick-start-footer__restartbtn"
+          className="pfe-quick-start-footer__restartbtn"
           onClick={onRestart}
           data-testid="qs-drawer-side-note-action"
         >
@@ -118,7 +118,7 @@ const QuickStartFooter: React.FC<QuickStartFooterProps> = ({
   );
 
   return (
-    <div className={`co-quick-start-footer ${footerClass}`}>
+    <div className={`pfe-quick-start-footer ${footerClass}`}>
       {getPrimaryButton}
       {getSecondaryButton}
       {getSideNoteAction}

--- a/packages/module/src/controller/QuickStartTaskHeader.scss
+++ b/packages/module/src/controller/QuickStartTaskHeader.scss
@@ -1,4 +1,4 @@
-.co-quick-start-task-header {
+.pfe-quick-start-task-header {
   display: flex;
   flex-wrap: wrap;
   align-items: center;

--- a/packages/module/src/controller/QuickStartTaskHeader.scss
+++ b/packages/module/src/controller/QuickStartTaskHeader.scss
@@ -1,4 +1,4 @@
-.pfe-quick-start-task-header {
+.pfext-quick-start-task-header {
   display: flex;
   flex-wrap: wrap;
   align-items: center;

--- a/packages/module/src/controller/QuickStartTaskHeader.tsx
+++ b/packages/module/src/controller/QuickStartTaskHeader.tsx
@@ -28,22 +28,22 @@ const TaskIcon: React.FC<{ taskIndex: number; taskStatus: QuickStartTaskStatus }
   switch (taskStatus) {
     case QuickStartTaskStatus.SUCCESS:
       return (
-        <span className="pfe-icon-and-text__icon">
-          <CheckCircleIcon size="md" className="pfe-quick-start-task-header__task-icon-success" />
+        <span className="pfext-icon-and-text__icon">
+          <CheckCircleIcon size="md" className="pfext-quick-start-task-header__task-icon-success" />
         </span>
       );
     case QuickStartTaskStatus.FAILED:
       return (
-        <span className="pfe-icon-and-text__icon">
+        <span className="pfext-icon-and-text__icon">
           <ExclamationCircleIcon
             size="md"
-            className="pfe-quick-start-task-header__task-icon-failed"
+            className="pfext-quick-start-task-header__task-icon-failed"
           />
         </span>
       );
     default:
       return (
-        <span className="pfe-icon-and-text__icon pfe-quick-start-task-header__task-icon-init">
+        <span className="pfext-icon-and-text__icon pfext-quick-start-task-header__task-icon-init">
           {getResource('{{taskIndex, number}}', taskIndex).replace(
             '{{taskIndex, number}}',
             taskIndex,
@@ -62,13 +62,13 @@ const QuickStartTaskHeader: React.FC<QuickStartTaskHeaderProps> = ({
   isActiveTask,
   onTaskSelect,
 }) => {
-  const classNames = css('pfe-quick-start-task-header__title', {
-    'pfe-quick-start-task-header__title-success': taskStatus === QuickStartTaskStatus.SUCCESS,
-    'pfe-quick-start-task-header__title-failed': taskStatus === QuickStartTaskStatus.FAILED,
+  const classNames = css('pfext-quick-start-task-header__title', {
+    'pfext-quick-start-task-header__title-success': taskStatus === QuickStartTaskStatus.SUCCESS,
+    'pfext-quick-start-task-header__title-failed': taskStatus === QuickStartTaskStatus.FAILED,
   });
 
   const content = (
-    <span className="pfe-quick-start-task-header">
+    <span className="pfext-quick-start-task-header">
       <Title headingLevel="h3" size={size} className={classNames}>
         <TaskIcon taskIndex={taskIndex} taskStatus={taskStatus} />
         <span dangerouslySetInnerHTML={{ __html: removeParagraphWrap(markdownConvert(title)) }} />
@@ -76,7 +76,7 @@ const QuickStartTaskHeader: React.FC<QuickStartTaskHeaderProps> = ({
           <>
             {' '}
             <span
-              className="pfe-quick-start-task-header__subtitle text-secondary"
+              className="pfext-quick-start-task-header__subtitle text-secondary"
               data-test-id="quick-start-task-subtitle"
             >
               {subtitle}
@@ -88,7 +88,7 @@ const QuickStartTaskHeader: React.FC<QuickStartTaskHeaderProps> = ({
   );
 
   return (
-    <div className="pfe-quick-start-task-header">
+    <div className="pfext-quick-start-task-header">
       <WizardNavItem
         content={content}
         step={taskIndex}

--- a/packages/module/src/controller/QuickStartTaskHeader.tsx
+++ b/packages/module/src/controller/QuickStartTaskHeader.tsx
@@ -28,22 +28,22 @@ const TaskIcon: React.FC<{ taskIndex: number; taskStatus: QuickStartTaskStatus }
   switch (taskStatus) {
     case QuickStartTaskStatus.SUCCESS:
       return (
-        <span className="co-icon-and-text__icon">
-          <CheckCircleIcon size="md" className="co-quick-start-task-header__task-icon-success" />
+        <span className="pfe-icon-and-text__icon">
+          <CheckCircleIcon size="md" className="pfe-quick-start-task-header__task-icon-success" />
         </span>
       );
     case QuickStartTaskStatus.FAILED:
       return (
-        <span className="co-icon-and-text__icon">
+        <span className="pfe-icon-and-text__icon">
           <ExclamationCircleIcon
             size="md"
-            className="co-quick-start-task-header__task-icon-failed"
+            className="pfe-quick-start-task-header__task-icon-failed"
           />
         </span>
       );
     default:
       return (
-        <span className="co-icon-and-text__icon co-quick-start-task-header__task-icon-init">
+        <span className="pfe-icon-and-text__icon pfe-quick-start-task-header__task-icon-init">
           {getResource('{{taskIndex, number}}', taskIndex).replace(
             '{{taskIndex, number}}',
             taskIndex,
@@ -62,13 +62,13 @@ const QuickStartTaskHeader: React.FC<QuickStartTaskHeaderProps> = ({
   isActiveTask,
   onTaskSelect,
 }) => {
-  const classNames = css('co-quick-start-task-header__title', {
-    'co-quick-start-task-header__title-success': taskStatus === QuickStartTaskStatus.SUCCESS,
-    'co-quick-start-task-header__title-failed': taskStatus === QuickStartTaskStatus.FAILED,
+  const classNames = css('pfe-quick-start-task-header__title', {
+    'pfe-quick-start-task-header__title-success': taskStatus === QuickStartTaskStatus.SUCCESS,
+    'pfe-quick-start-task-header__title-failed': taskStatus === QuickStartTaskStatus.FAILED,
   });
 
   const content = (
-    <span className="co-quick-start-task-header">
+    <span className="pfe-quick-start-task-header">
       <Title headingLevel="h3" size={size} className={classNames}>
         <TaskIcon taskIndex={taskIndex} taskStatus={taskStatus} />
         <span dangerouslySetInnerHTML={{ __html: removeParagraphWrap(markdownConvert(title)) }} />
@@ -76,7 +76,7 @@ const QuickStartTaskHeader: React.FC<QuickStartTaskHeaderProps> = ({
           <>
             {' '}
             <span
-              className="co-quick-start-task-header__subtitle text-secondary"
+              className="pfe-quick-start-task-header__subtitle text-secondary"
               data-test-id="quick-start-task-subtitle"
             >
               {subtitle}
@@ -88,7 +88,7 @@ const QuickStartTaskHeader: React.FC<QuickStartTaskHeaderProps> = ({
   );
 
   return (
-    <div className="co-quick-start-task-header">
+    <div className="pfe-quick-start-task-header">
       <WizardNavItem
         content={content}
         step={taskIndex}

--- a/packages/module/src/controller/QuickStartTaskReview.scss
+++ b/packages/module/src/controller/QuickStartTaskReview.scss
@@ -1,4 +1,4 @@
-.pfe-quick-start-task-review {
+.pfext-quick-start-task-review {
   font-size: var(--pf-global--FontSize--md);
   line-height: var(--pf-global--FontSize--xl);
   font-family: var(--pf-global--FontFamily--heading--sans-serif);

--- a/packages/module/src/controller/QuickStartTaskReview.scss
+++ b/packages/module/src/controller/QuickStartTaskReview.scss
@@ -1,4 +1,4 @@
-.co-quick-start-task-review {
+.pfe-quick-start-task-review {
   font-size: var(--pf-global--FontSize--md);
   line-height: var(--pf-global--FontSize--xl);
   font-family: var(--pf-global--FontFamily--heading--sans-serif);

--- a/packages/module/src/controller/QuickStartTaskReview.tsx
+++ b/packages/module/src/controller/QuickStartTaskReview.tsx
@@ -35,9 +35,9 @@ const QuickStartTaskReview: React.FC<QuickStartTaskReviewProps> = ({
   const { instructions, failedTaskHelp: taskHelp } = review;
   const { getResource } = React.useContext<QuickStartContextValues>(QuickStartContext);
 
-  const alertClassNames = css('pfe-quick-start-task-review', {
-    'pfe-quick-start-task-review--success': taskStatus === QuickStartTaskStatus.SUCCESS,
-    'pfe-quick-start-task-review--failed': taskStatus === QuickStartTaskStatus.FAILED,
+  const alertClassNames = css('pfext-quick-start-task-review', {
+    'pfext-quick-start-task-review--success': taskStatus === QuickStartTaskStatus.SUCCESS,
+    'pfext-quick-start-task-review--failed': taskStatus === QuickStartTaskStatus.FAILED,
   });
 
   const title = <span className={alertClassNames}>{getResource('Check your work')}</span>;
@@ -45,13 +45,13 @@ const QuickStartTaskReview: React.FC<QuickStartTaskReviewProps> = ({
   return (
     <Alert variant={getAlertVariant(taskStatus)} title={title} isInline>
       <QuickStartMarkdownView content={instructions} />
-      <span className="pfe-quick-start-task-review__actions">
+      <span className="pfext-quick-start-task-review__actions">
         <Radio
           id="review-success"
           name="review-success"
           data-testid="qs-drawer-check-yes"
           label={getResource('Yes')}
-          className="pfe-quick-start-task-review__radio"
+          className="pfext-quick-start-task-review__radio"
           isChecked={taskStatus === QuickStartTaskStatus.SUCCESS}
           onChange={() => onTaskReview(QuickStartTaskStatus.SUCCESS)}
         />
@@ -60,7 +60,7 @@ const QuickStartTaskReview: React.FC<QuickStartTaskReviewProps> = ({
           name="review-failed"
           data-testid="qs-drawer-check-no"
           label={getResource('No')}
-          className="pfe-quick-start-task-review__radio"
+          className="pfext-quick-start-task-review__radio"
           isChecked={taskStatus === QuickStartTaskStatus.FAILED}
           onChange={() => onTaskReview(QuickStartTaskStatus.FAILED)}
         />

--- a/packages/module/src/controller/QuickStartTaskReview.tsx
+++ b/packages/module/src/controller/QuickStartTaskReview.tsx
@@ -35,9 +35,9 @@ const QuickStartTaskReview: React.FC<QuickStartTaskReviewProps> = ({
   const { instructions, failedTaskHelp: taskHelp } = review;
   const { getResource } = React.useContext<QuickStartContextValues>(QuickStartContext);
 
-  const alertClassNames = css('co-quick-start-task-review', {
-    'co-quick-start-task-review--success': taskStatus === QuickStartTaskStatus.SUCCESS,
-    'co-quick-start-task-review--failed': taskStatus === QuickStartTaskStatus.FAILED,
+  const alertClassNames = css('pfe-quick-start-task-review', {
+    'pfe-quick-start-task-review--success': taskStatus === QuickStartTaskStatus.SUCCESS,
+    'pfe-quick-start-task-review--failed': taskStatus === QuickStartTaskStatus.FAILED,
   });
 
   const title = <span className={alertClassNames}>{getResource('Check your work')}</span>;
@@ -45,13 +45,13 @@ const QuickStartTaskReview: React.FC<QuickStartTaskReviewProps> = ({
   return (
     <Alert variant={getAlertVariant(taskStatus)} title={title} isInline>
       <QuickStartMarkdownView content={instructions} />
-      <span className="co-quick-start-task-review__actions">
+      <span className="pfe-quick-start-task-review__actions">
         <Radio
           id="review-success"
           name="review-success"
           data-testid="qs-drawer-check-yes"
           label={getResource('Yes')}
-          className="co-quick-start-task-review__radio"
+          className="pfe-quick-start-task-review__radio"
           isChecked={taskStatus === QuickStartTaskStatus.SUCCESS}
           onChange={() => onTaskReview(QuickStartTaskStatus.SUCCESS)}
         />
@@ -60,7 +60,7 @@ const QuickStartTaskReview: React.FC<QuickStartTaskReviewProps> = ({
           name="review-failed"
           data-testid="qs-drawer-check-no"
           label={getResource('No')}
-          className="co-quick-start-task-review__radio"
+          className="pfe-quick-start-task-review__radio"
           isChecked={taskStatus === QuickStartTaskStatus.FAILED}
           onChange={() => onTaskReview(QuickStartTaskStatus.FAILED)}
         />

--- a/packages/module/src/quickstarts-patternfly.ts
+++ b/packages/module/src/quickstarts-patternfly.ts
@@ -1,1 +1,0 @@
-import './vendor-patternfly.scss';

--- a/packages/module/src/quickstarts-patternfly.ts
+++ b/packages/module/src/quickstarts-patternfly.ts
@@ -1,0 +1,1 @@
+import './vendor-patternfly.scss';

--- a/packages/module/src/react-catalog-view-extension/CatalogTile.tsx
+++ b/packages/module/src/react-catalog-view-extension/CatalogTile.tsx
@@ -1,0 +1,148 @@
+import * as React from 'react';
+import {
+  Card,
+  CardActions,
+  CardHeader,
+  CardTitle,
+  CardBody,
+  CardFooter,
+} from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
+
+export interface CatalogTileProps extends Omit<React.HTMLProps<HTMLElement>, 'title'> {
+  /** Id */
+  id?: any;
+  /** Additional css classes */
+  className?: string;
+  /** Flag if the tile is 'featured' */
+  featured: boolean;
+  /** Callback for a click on the tile */
+  onClick?: (event: React.SyntheticEvent<HTMLElement>) => void;
+  /** href for the tile if used as a link */
+  href: string;
+  /** URL of an image for the item's icon */
+  iconImg?: string;
+  /** Alternate text for the item's icon */
+  iconAlt?: string;
+  /** Class for the image when an icon is to be used (exclusive from iconImg) */
+  iconClass?: string;
+  /** Alternatively provided JSX for the icon */
+  icon?: React.ReactNode;
+  /** Array of badges */
+  badges?: React.ReactNode[];
+  /** Tile for the catalog item */
+  title: string | React.ReactNode;
+  /** Vendor for the catalog item */
+  vendor?: string | React.ReactNode;
+  /** Description of the catalog item */
+  description?: string | React.ReactNode;
+  /** Footer for the tile */
+  footer?: string | React.ReactNode;
+  /** Body content that isn't truncated */
+  children?: React.ReactNode;
+}
+
+export class CatalogTile extends React.Component<CatalogTileProps> {
+  static displayName = 'CatalogTile';
+  static defaultProps = {
+    id: null as any,
+    className: '',
+    featured: false,
+    onClick: null as (event: React.SyntheticEvent<HTMLElement>) => void,
+    href: null as string,
+    iconImg: null as string,
+    iconAlt: '',
+    iconClass: '',
+    icon: null as React.ReactNode,
+    badges: [] as React.ReactNode[],
+    vendor: null as string | React.ReactNode,
+    description: null as string | React.ReactNode,
+    footer: null as string | React.ReactNode,
+    children: null as React.ReactNode,
+  };
+
+  private handleClick = (e: React.SyntheticEvent<HTMLElement>) => {
+    const { onClick, href } = this.props;
+
+    if (!href) {
+      e.preventDefault();
+    }
+    if (onClick) {
+      onClick(e);
+    }
+  };
+
+  private renderBadges = (badges: React.ReactNode[]) => {
+    if (!badges || !badges.length) {
+      return null;
+    }
+
+    return (
+      <div className="catalog-tile-pf-badge-container">
+        {badges.map((badge, index) => (
+          <span key={`badge-${index}`}>{badge}</span>
+        ))}
+      </div>
+    );
+  };
+
+  render() {
+    const {
+      id,
+      className,
+      featured,
+      onClick,
+      href,
+      icon,
+      iconImg,
+      iconAlt,
+      iconClass,
+      badges,
+      title,
+      vendor,
+      description,
+      footer,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      ref,
+      children,
+      ...props
+    } = this.props;
+
+    return (
+      <Card
+        component={href || onClick ? 'a' : 'div'}
+        id={id}
+        href={href || '#'}
+        className={css('catalog-tile-pf', { featured }, className)}
+        onClick={(e) => this.handleClick(e)}
+        isHoverable
+        {...props}
+      >
+        {(badges.length > 0 || iconImg || iconClass || icon) && (
+          <CardHeader>
+            {iconImg && <img className="catalog-tile-pf-icon" src={iconImg} alt={iconAlt} />}
+            {!iconImg && (iconClass || icon) && (
+              <span className={`catalog-tile-pf-icon ${iconClass}`}>{icon}</span>
+            )}
+            {badges.length > 0 && <CardActions>{this.renderBadges(badges)}</CardActions>}
+          </CardHeader>
+        )}
+        <CardTitle className="catalog-tile-pf-header">
+          <div className="catalog-tile-pf-title">{title}</div>
+          {vendor && <div className="catalog-tile-pf-subtitle">{vendor}</div>}
+        </CardTitle>
+        {(description || children) && (
+          <CardBody className="catalog-tile-pf-body">
+            {description && (
+              <div className="catalog-tile-pf-description">
+                <span className={css({ 'has-footer': footer })}>{description}</span>
+              </div>
+            )}
+            {children}
+          </CardBody>
+        )}
+        {footer && <CardFooter className="catalog-tile-pf-footer">{footer}</CardFooter>}
+      </Card>
+    );
+  }
+}

--- a/packages/module/src/react-catalog-view-extension/CatalogTile.tsx
+++ b/packages/module/src/react-catalog-view-extension/CatalogTile.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable no-unused-vars */
 import * as React from 'react';
 import {
   Card,
@@ -102,7 +104,7 @@ export class CatalogTile extends React.Component<CatalogTileProps> {
       vendor,
       description,
       footer,
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      // unused-var
       ref,
       children,
       ...props

--- a/packages/module/src/style.scss
+++ b/packages/module/src/style.scss
@@ -1,3 +1,9 @@
+@import './ConsoleInternal/style/vars';
+@import '~patternfly/dist/sass/patternfly/variables';
+@import '~bootstrap-sass/assets/stylesheets/bootstrap/variables';
+@import '~bootstrap-sass/assets/stylesheets/bootstrap/mixins';
+@import '~patternfly/dist/sass/patternfly/bootstrap-mixin-overrides';
+
 @import './ConsoleInternal/vendor.scss';
 @import './ConsoleInternal/style.scss';
 @import 'ConsoleShared/src/components/layout/PageLayout.scss';

--- a/packages/module/src/vendor-bootstrap.scss
+++ b/packages/module/src/vendor-bootstrap.scss
@@ -1,4 +1,4 @@
-.co-markdown-view {
+.pfe-markdown-view {
   @import './ConsoleInternal/style/vars';
   @import '~patternfly/dist/sass/patternfly/variables';
   @import '~bootstrap-sass/assets/stylesheets/bootstrap/variables';

--- a/packages/module/src/vendor-bootstrap.scss
+++ b/packages/module/src/vendor-bootstrap.scss
@@ -1,4 +1,4 @@
-.pfe-markdown-view {
+.pfext-markdown-view {
   @import './ConsoleInternal/style/vars';
   @import '~patternfly/dist/sass/patternfly/variables';
   @import '~bootstrap-sass/assets/stylesheets/bootstrap/variables';

--- a/packages/module/src/vendor-patternfly.scss
+++ b/packages/module/src/vendor-patternfly.scss
@@ -1,0 +1,4 @@
+// @import "./ConsoleInternal/style/vars";
+
+@import "~@patternfly/patternfly/patternfly.scss";
+@import "~@patternfly/patternfly/patternfly-addons.scss";

--- a/packages/module/src/vendor-patternfly.scss
+++ b/packages/module/src/vendor-patternfly.scss
@@ -1,4 +1,0 @@
-// @import "./ConsoleInternal/style/vars";
-
-@import "~@patternfly/patternfly/patternfly.scss";
-@import "~@patternfly/patternfly/patternfly-addons.scss";

--- a/packages/vscode/src/view/app/index.css
+++ b/packages/vscode/src/view/app/index.css
@@ -2,6 +2,6 @@ html, body, #root, .pf-c-drawer, .pf-c-drawer__main, .pf-c-drawer__content {
   height: 100%;
 }
 
-.pf-c-drawer__panel.pfe-quick-start-panel-content {
+.pf-c-drawer__panel.pfext-quick-start-panel-content {
   flex-basis: 450px !important;
 }

--- a/packages/vscode/src/view/app/index.css
+++ b/packages/vscode/src/view/app/index.css
@@ -2,6 +2,6 @@ html, body, #root, .pf-c-drawer, .pf-c-drawer__main, .pf-c-drawer__content {
   height: 100%;
 }
 
-.pf-c-drawer__panel.co-quick-start-panel-content {
+.pf-c-drawer__panel.pfe-quick-start-panel-content {
   flex-basis: 450px !important;
 }

--- a/snapshots.js
+++ b/snapshots.js
@@ -8,7 +8,7 @@ const runThroughQuickStart = async (id, page, percySnapshot) => {
   };
   await page.goto(`http://localhost:3000/quickstarts?quickstart=${id}`);
   // ensure the page has loaded before capturing a snapshot
-  await page.waitFor('.pf-c-drawer__panel.co-quick-start-panel-content');
+  await page.waitFor('.pf-c-drawer__panel.pfe-quick-start-panel-content');
   withSnapshots && (await percySnapshot(`${id}__intro`, snapshotOptions));
 
   await page.click('[data-test="Start button"]');
@@ -41,7 +41,7 @@ const runThroughQuickStart = async (id, page, percySnapshot) => {
 PercyScript.run(async (page, percySnapshot) => {
   // catalog screenshot
   await page.goto('http://localhost:3000/quickstarts');
-  await page.waitFor('.co-quick-start-tile');
+  await page.waitFor('.pfe-quick-start-tile');
   withSnapshots && (await percySnapshot('catalog', { widths: [1280] }));
 
   // quick starts

--- a/snapshots.js
+++ b/snapshots.js
@@ -8,7 +8,7 @@ const runThroughQuickStart = async (id, page, percySnapshot) => {
   };
   await page.goto(`http://localhost:3000/quickstarts?quickstart=${id}`);
   // ensure the page has loaded before capturing a snapshot
-  await page.waitFor('.pf-c-drawer__panel.pfe-quick-start-panel-content');
+  await page.waitFor('.pf-c-drawer__panel.pfext-quick-start-panel-content');
   withSnapshots && (await percySnapshot(`${id}__intro`, snapshotOptions));
 
   await page.click('[data-test="Start button"]');
@@ -41,7 +41,7 @@ const runThroughQuickStart = async (id, page, percySnapshot) => {
 PercyScript.run(async (page, percySnapshot) => {
   // catalog screenshot
   await page.goto('http://localhost:3000/quickstarts');
-  await page.waitFor('.pfe-quick-start-tile');
+  await page.waitFor('.pfext-quick-start-tile');
   withSnapshots && (await percySnapshot('catalog', { widths: [1280] }));
 
   // quick starts

--- a/yarn.lock
+++ b/yarn.lock
@@ -276,16 +276,6 @@
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.70.2.tgz#94b733f68f4f63040ab142eb2fa3c3ac5d08f2ae"
   integrity sha512-XKCHnOjx1JThY3s98AJhsApSsGHPvEdlY7r+b18OecqUnmThVGw3nslzYYrwfCGlJ/xQtV5so29SduH2/uhHzA==
 
-"@patternfly/react-catalog-view-extension@4.12.15":
-  version "4.12.15"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-catalog-view-extension/-/react-catalog-view-extension-4.12.15.tgz#edb0d6b97b3adf060129fdd1e0c1edc25c31d22e"
-  integrity sha512-1mp+Ogi7fJfgh5wV9q+PolmplbMj3Tcias8xs0eeD5GCirdzOQxG+wihEM5k6CAGhBAr7jHg5fRSgO8QLTt3UQ==
-  dependencies:
-    "@patternfly/patternfly" "4.122.2"
-    "@patternfly/react-core" "^4.135.15"
-    "@patternfly/react-styles" "^4.11.4"
-    classnames "^2.2.5"
-
 "@patternfly/react-catalog-view-extension@^4.10.13", "@patternfly/react-catalog-view-extension@^4.8.126":
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/@patternfly/react-catalog-view-extension/-/react-catalog-view-extension-4.12.0.tgz#86b407ab43994006f355e321ecada429a018e26a"
@@ -318,19 +308,6 @@
     "@patternfly/react-icons" "^4.11.0"
     "@patternfly/react-styles" "^4.11.0"
     "@patternfly/react-tokens" "^4.12.0"
-    focus-trap "6.2.2"
-    react-dropzone "9.0.0"
-    tippy.js "5.1.2"
-    tslib "1.13.0"
-
-"@patternfly/react-core@^4.135.15":
-  version "4.140.0"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.140.0.tgz#5004d41d286cd68acda66a79c62712b890ba67e5"
-  integrity sha512-1S84CXoF49yMo+91d0Hm0vEVU7ycOuD8FqRDKx+wpo3ePoIf4hLWzUEc36mZgdB+cDYYmVvXsWytrQwazczAWg==
-  dependencies:
-    "@patternfly/react-icons" "^4.11.4"
-    "@patternfly/react-styles" "^4.11.4"
-    "@patternfly/react-tokens" "^4.12.5"
     focus-trap "6.2.2"
     react-dropzone "9.0.0"
     tippy.js "5.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -310,7 +310,7 @@
     tippy.js "5.1.2"
     tslib "1.13.0"
 
-"@patternfly/react-core@^4.101.3", "@patternfly/react-core@^4.135.0", "@patternfly/react-core@^4.84.4":
+"@patternfly/react-core@^4.135.0", "@patternfly/react-core@^4.84.4":
   version "4.135.0"
   resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.135.0.tgz#b64ad4da10a8814926e28fad727bc7690cd60e66"
   integrity sha512-DZcONUGOR7Znd6BsUJ4L+KrrnIpyjUvh3JNcYiHW3loytxShCGcx+a04QjOOcZm+MtFhkgs/t51yiC5IP12abA==


### PR DESCRIPTION
Closes https://github.com/patternfly/patternfly-quickstarts/issues/23

Use `pfext` prefix for classes instead of `ocs` / `co`