### PR TITLE
support multiple next quick start links in conclusion

### DIFF
--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -9,7 +9,7 @@
     "serve": "serve public"
   },
   "dependencies": {
-    "@patternfly/quickstarts": "1.2.2",
+    "@patternfly/quickstarts": "1.2.3",
     "@patternfly/react-core": "^4.135.0",
     "asciidoctor": "^2.2.1",
     "i18next": "^19.8.3",

--- a/packages/dev/src/quickstarts-data/mocks/yamls/add-healthchecks-quickstart.yaml
+++ b/packages/dev/src/quickstarts-data/mocks/yamls/add-healthchecks-quickstart.yaml
@@ -76,4 +76,4 @@ spec:
         failed: Try the steps again.
   conclusion: Your sample application now has health checks. To ensure that your application
     is running correctly, take the **Monitor your sample application** quick start.
-  nextQuickStart: [monitor-sampleapp]
+  nextQuickStart: [monitor-sampleapp, sample-application]

--- a/packages/module/package.json
+++ b/packages/module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patternfly/quickstarts",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "PatternFly quick starts",
   "files": [
     "dist"

--- a/packages/module/src/controller/QuickStartConclusion.tsx
+++ b/packages/module/src/controller/QuickStartConclusion.tsx
@@ -10,7 +10,7 @@ type QuickStartConclusionProps = {
   tasks: QuickStartTask[];
   conclusion: string;
   allTaskStatuses: QuickStartTaskStatus[];
-  nextQuickStart?: QuickStart;
+  nextQuickStarts?: QuickStart[];
   onQuickStartChange: (quickStartid: string) => void;
   onTaskSelect: (selectedTaskNumber: number) => void;
 };
@@ -19,12 +19,11 @@ const QuickStartConclusion: React.FC<QuickStartConclusionProps> = ({
   tasks,
   conclusion,
   allTaskStatuses,
-  nextQuickStart,
+  nextQuickStarts,
   onQuickStartChange,
   onTaskSelect,
 }) => {
   const hasFailedTask = allTaskStatuses.includes(QuickStartTaskStatus.FAILED);
-  const nextQSDisplayName = nextQuickStart?.spec?.displayName;
   const { getResource } = React.useContext<QuickStartContextValues>(QuickStartContext);
   return (
     <>
@@ -38,21 +37,26 @@ const QuickStartConclusion: React.FC<QuickStartConclusionProps> = ({
             : conclusion
         }
       />
-      {nextQuickStart && !hasFailedTask && (
-        <Button
-          variant="link"
-          onClick={() => onQuickStartChange(nextQuickStart.metadata.name)}
-          isInline
-        >
-          {getResource('Start {{nextQSDisplayName}} quick start').replace(
-            '{{nextQSDisplayName}}',
-            nextQSDisplayName,
-          )}{' '}
-          <ArrowRightIcon
-            style={{ marginLeft: 'var(--pf-global--spacer--xs)', verticalAlign: 'middle' }}
-          />
-        </Button>
-      )}
+      {!hasFailedTask &&
+        nextQuickStarts &&
+        nextQuickStarts.length > 0 &&
+        nextQuickStarts.map((nextQuickStart, index) => (
+          <Button
+            variant="link"
+            onClick={() => onQuickStartChange(nextQuickStart.metadata.name)}
+            isInline
+            isBlock
+            key={index}
+          >
+            {getResource('Start {{nextQSDisplayName}} quick start').replace(
+              '{{nextQSDisplayName}}',
+              nextQuickStart?.spec?.displayName,
+            )}{' '}
+            <ArrowRightIcon
+              style={{ marginLeft: 'var(--pf-global--spacer--xs)', verticalAlign: 'middle' }}
+            />
+          </Button>
+        ))}
     </>
   );
 };

--- a/packages/module/src/controller/QuickStartContent.tsx
+++ b/packages/module/src/controller/QuickStartContent.tsx
@@ -33,7 +33,6 @@ const QuickStartContent = React.forwardRef<HTMLDivElement, QuickStartContentProp
       spec: { introduction, tasks, conclusion },
     } = quickStart;
     const totalTasks = tasks.length;
-    const nextQS = nextQuickStarts.length > 0 && nextQuickStarts[0];
 
     return (
       <div className="pfext-quick-start-content" ref={ref}>
@@ -59,7 +58,7 @@ const QuickStartContent = React.forwardRef<HTMLDivElement, QuickStartContentProp
             tasks={tasks}
             conclusion={conclusion}
             allTaskStatuses={allTaskStatuses}
-            nextQuickStart={nextQS}
+            nextQuickStarts={nextQuickStarts}
             onQuickStartChange={onQuickStartChange}
             onTaskSelect={onTaskSelect}
           />

--- a/packages/module/src/controller/__tests__/QuickStartConclusion.spec.tsx
+++ b/packages/module/src/controller/__tests__/QuickStartConclusion.spec.tsx
@@ -55,7 +55,7 @@ describe('QuickStartConclusion', () => {
     wrapper = shallow(
       <QuickStartConclusion
         {...props}
-        nextQuickStart={getQuickStartByName('explore-pipelines', allQuickStarts)}
+        nextQuickStarts={[getQuickStartByName('explore-pipelines', allQuickStarts)]}
       />,
     );
     expect(


### PR DESCRIPTION
<img width="441" alt="Screen Shot 2021-09-09 at 4 42 16 PM" src="https://user-images.githubusercontent.com/869106/132759696-ca2be86b-7cee-46f1-ba90-593f24434194.png">

Example ^

Towards https://github.com/patternfly/patternfly-quickstarts/issues/30