### PR TITLE
feat(QuickStartFooter): always show restart action in footer

### DIFF
--- a/packages/module/src/controller/QuickStartFooter.tsx
+++ b/packages/module/src/controller/QuickStartFooter.tsx
@@ -103,8 +103,7 @@ const QuickStartFooter: React.FC<QuickStartFooterProps> = ({
 
   const getSideNoteAction = React.useMemo(
     () =>
-      status === QuickStartStatus.COMPLETE &&
-      taskNumber === totalTasks && (
+      taskNumber !== -1 && (
         <Button
           variant="link"
           className="pfext-quick-start-footer__restartbtn"
@@ -114,7 +113,7 @@ const QuickStartFooter: React.FC<QuickStartFooterProps> = ({
           {SecondaryButtonText.RESTART}
         </Button>
       ),
-    [status, SecondaryButtonText, onRestart, taskNumber, totalTasks],
+    [taskNumber, onRestart, SecondaryButtonText.RESTART],
   );
 
   return (

--- a/packages/module/src/controller/__tests__/QuickStartFooter.spec.tsx
+++ b/packages/module/src/controller/__tests__/QuickStartFooter.spec.tsx
@@ -18,8 +18,8 @@ describe('QuickStartFooter', () => {
   beforeEach(() => {
     spyOn(React, 'useContext').and.returnValue({
       activeQuickStartID: '',
-      startQuickStart: () => {},
-      restartQuickStart: () => {},
+      startQuickStart: () => { },
+      restartQuickStart: () => { },
       getResource: (key) => `quickstart~${key}`,
     });
   });
@@ -76,7 +76,7 @@ describe('QuickStartFooter', () => {
     ).toBe('quickstart~Restart');
   });
 
-  it('should load Next and Back buttons for in progress tours in task page', () => {
+  it('should load Next and Back buttons, and Restart link for in progress tours in task page', () => {
     quickStartFooterProps = {
       status: QuickStartStatus.IN_PROGRESS,
       footerClass: 'test',
@@ -90,7 +90,7 @@ describe('QuickStartFooter', () => {
     const quickStartFooterWrapper = shallow(<QuickStartFooter {...quickStartFooterProps} />);
     const footerButtons = quickStartFooterWrapper.find(Button);
     expect(footerButtons.exists()).toBeTruthy();
-    expect(footerButtons.length).toEqual(2);
+    expect(footerButtons.length).toEqual(3);
     expect(
       footerButtons
         .at(0)
@@ -103,6 +103,12 @@ describe('QuickStartFooter', () => {
         .childAt(0)
         .text(),
     ).toBe('quickstart~Back');
+    expect(
+      footerButtons
+        .at(2)
+        .childAt(0)
+        .text(),
+    ).toBe('quickstart~Restart');
   });
 
   it('should load Close, Back and Restart buttons for completed tours in conclusion page', () => {

--- a/packages/module/src/controller/__tests__/QuickStartFooter.spec.tsx
+++ b/packages/module/src/controller/__tests__/QuickStartFooter.spec.tsx
@@ -18,8 +18,8 @@ describe('QuickStartFooter', () => {
   beforeEach(() => {
     spyOn(React, 'useContext').and.returnValue({
       activeQuickStartID: '',
-      startQuickStart: () => { },
-      restartQuickStart: () => { },
+      startQuickStart: () => {},
+      restartQuickStart: () => {},
       getResource: (key) => `quickstart~${key}`,
     });
   });


### PR DESCRIPTION
Closes #28 

After clicking the restart `link` that appears on the bottom right, or after starting a QS then clicking back, the restart `button` appears to the right of the continue button, but still in the bottom left. To me it should be removed when the continue button is there, but possibly I am missing its use case.

![image](https://user-images.githubusercontent.com/87719785/133633036-4fb12e4c-61ce-4f92-a60d-4fb915a33cbc.png)

For clarity this is the restart link which will appear on every screen except the initial one:
![image](https://user-images.githubusercontent.com/87719785/133634147-2fbd0ef6-0090-4663-ab34-845b008ad540.png)

