### PR TITLE
Quickstarts standalone

### DIFF
--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -9,7 +9,7 @@
     "serve": "serve public"
   },
   "dependencies": {
-    "@patternfly/quickstarts": "1.3.0",
+    "@patternfly/quickstarts": "1.4.0",
     "@patternfly/transform-adoc": "*",
     "@patternfly/react-core": "^4.135.0",
     "asciidoctor": "^2.2.1",

--- a/packages/dev/src/common/Page.tsx
+++ b/packages/dev/src/common/Page.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {
   PageHeaderTools,
   Button,
-  Avatar,
   PageHeader,
   Brand,
   Nav,
@@ -13,7 +12,6 @@ import {
 import { Link } from 'react-router-dom';
 import Demos from '../Demos';
 import { SettingsModal } from '../SettingsModal';
-import imgAvatar from '../assets/images/imgAvatar.svg';
 import imgBrand from '../assets/images/imgBrand.svg';
 
 const AppToolbar = () => {
@@ -25,7 +23,6 @@ const AppToolbar = () => {
         Settings
       </Button>
       <SettingsModal isOpen={isModalOpen} onClose={onModalClose} />
-      {/* <Avatar src={imgAvatar} alt="Avatar image" /> */}
     </PageHeaderTools>
   );
 };

--- a/packages/dev/src/common/Page.tsx
+++ b/packages/dev/src/common/Page.tsx
@@ -25,7 +25,7 @@ const AppToolbar = () => {
         Settings
       </Button>
       <SettingsModal isOpen={isModalOpen} onClose={onModalClose} />
-      <Avatar src={imgAvatar} alt="Avatar image" />
+      {/* <Avatar src={imgAvatar} alt="Avatar image" /> */}
     </PageHeaderTools>
   );
 };

--- a/packages/dev/src/index.tsx
+++ b/packages/dev/src/index.tsx
@@ -4,7 +4,7 @@ import '@patternfly/quickstarts/dist/patternfly-global.css';
 // PF styles nested within .pfext-quick-start__base
 import '@patternfly/quickstarts/dist/patternfly-nested.css';
 // quick starts styles
-import '@patternfly/quickstarts/dist/quickstarts.css';
+import '@patternfly/quickstarts/dist/quickstarts-standalone.css';
 import '@patternfly/transform-adoc/dist/transform-adoc.css';
 
 import React from 'react';

--- a/packages/dev/src/index.tsx
+++ b/packages/dev/src/index.tsx
@@ -1,4 +1,9 @@
 import '@patternfly/react-core/dist/styles/base.css';
+// global styles for Drawer, Popover, Modal (including Backdrop and Bullseye)
+import '@patternfly/quickstarts/dist/patternfly-global.css';
+// PF styles nested within .pfext-quick-start__base
+import '@patternfly/quickstarts/dist/patternfly-nested.css';
+// quick starts styles
 import '@patternfly/quickstarts/dist/quickstarts.css';
 import '@patternfly/transform-adoc/dist/transform-adoc.css';
 

--- a/packages/dev/src/index.tsx
+++ b/packages/dev/src/index.tsx
@@ -1,11 +1,15 @@
+// fonts, variables
 import '@patternfly/react-core/dist/styles/base.css';
-// global styles for Drawer, Popover, Modal (including Backdrop and Bullseye)
-import '@patternfly/quickstarts/dist/patternfly-global.css';
-// PF styles nested within .pfext-quick-start__base
-import '@patternfly/quickstarts/dist/patternfly-nested.css';
-// quick starts styles
-import '@patternfly/quickstarts/dist/quickstarts-standalone.css';
 import '@patternfly/transform-adoc/dist/transform-adoc.css';
+
+import '@patternfly/quickstarts/dist/quickstarts.css';
+
+// the following stylesheets are here for testing quickstarts-standalone
+
+// global styles for Drawer, Popover, Modal (including Backdrop and Bullseye)
+// import '@patternfly/quickstarts/dist/patternfly-global.css';
+// PF and quickstarts styles nested within .pfext-quick-start__base
+// import '@patternfly/quickstarts/dist/quickstarts-standalone.min.css';
 
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/packages/dev/webpack.config.js
+++ b/packages/dev/webpack.config.js
@@ -45,11 +45,11 @@ module.exports = (_env, argv) => {
           test: /\.css$/,
           use: cssLoaders,
         },
-        // {
-        //   test: /\.css$/,
-        //   include: (stylesheet) => stylesheet.includes('@patternfly/react-styles/css/'),
-        //   use: ['null-loader'],
-        // },
+        {
+          test: /\.css$/,
+          include: (stylesheet) => stylesheet.includes('@patternfly/react-styles/css/'),
+          use: ['null-loader'],
+        },
         {
           test: /\.(png|jpe?g|webp|gif|svg)$/,
           use: {
@@ -68,7 +68,7 @@ module.exports = (_env, argv) => {
             {
               loader: 'file-loader',
               options: {
-                name: '[name].[ext]',
+                name: '[name].[hash:8].[ext]',
                 outputPath: 'fonts/',
               },
             },

--- a/packages/dev/webpack.config.js
+++ b/packages/dev/webpack.config.js
@@ -45,11 +45,12 @@ module.exports = (_env, argv) => {
           test: /\.css$/,
           use: cssLoaders,
         },
-        {
-          test: /\.css$/,
-          include: (stylesheet) => stylesheet.includes('@patternfly/react-styles/css/'),
-          use: ['null-loader'],
-        },
+        // here for testing with quickstarts-standalone.css (see src/index.tsx)
+        // {
+        //   test: /\.css$/,
+        //   include: (stylesheet) => stylesheet.includes('@patternfly/react-styles/css/'),
+        //   use: ['null-loader'],
+        // },
         {
           test: /\.(png|jpe?g|webp|gif|svg)$/,
           use: {

--- a/packages/module/README.md
+++ b/packages/module/README.md
@@ -27,6 +27,23 @@ import '@patternfly/react-core/dist/styles/base.css';
 import '@patternfly/quickstarts/dist/quickstarts.min.css';
 ```
 
+### Stylesheets if you use an older version of PatternFly
+If you use an older version of @patternfly/react-core (older than "4.115.2"), and you can't upgrade yet, you can pull in the necessary PatternFly styles that @patternfly/quickstarts depends upon.
+
+Ideally @patternfly/quickstarts will use the consumer provided PatternFly styles, only use these stylesheets if really needed.
+
+`quickstarts-standalone.min.css` nests the css classes within a **.pfext-quick-start__base** parent, so that they have higher specificity. `patternfly-global.css` includes component styles that we cannot nest with more specificiy (for example Drawer since it can include consumer components that depend on an older PF version).
+
+> Note: Only use these stylesheets if necessary!
+```js
+// import base from PatternFly to get the font
+import '@patternfly/react-core/dist/styles/base.css';
+// some global styles and variables that quickstarts uses (Drawer, Popover, Modal, Backdrop, Bullseye)
+import '@patternfly/quickstarts/dist/patternfly-global.css';
+// PF and quickstarts styles nested within .pfext-quick-start__base
+import '@patternfly/quickstarts/dist/quickstarts-standalone.min.css';
+```
+
 ## Usage example
 
 Note: You can also view this example on [codesandbox](https://codesandbox.io/s/patternfly-quickstarts-finished-cnv53)!

--- a/packages/module/package.json
+++ b/packages/module/package.json
@@ -68,6 +68,7 @@
     "enzyme-adapter-react-16": "^1.15.5",
     "enzyme-to-json": "^3.6.1",
     "node-sass": "^6.0.1",
+    "node-sass-glob-importer": "^5.3.2",
     "prettier": "^2.1.2",
     "purgecss": "^4.0.0",
     "react": "^16.8.0",

--- a/packages/module/package.json
+++ b/packages/module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patternfly/quickstarts",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "PatternFly quick starts",
   "files": [
     "dist"

--- a/packages/module/package.json
+++ b/packages/module/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "clean": "rm -rf dist",
     "prebuild": "yarn clean",
-    "build": "rollup -c && yarn purge-css && yarn combine && yarn min-css",
+    "build": "rollup -c && yarn purge-css && yarn combine && yarn min-css && yarn min-css-standalone",
     "watch": "rollup -w --config rollup-quick.config.js",
     "quick": "rollup --config rollup-quick.config.js",
     "combine": "node ./combineCss.js",
@@ -29,9 +29,10 @@
     "type-check": "tsc --noEmit",
     "ci-checks": "yarn type-check && yarn lint && yarn test",
     "build:ts": "yarn clean && tsc --p tsconfig.json",
-    "post-css": "yarn purge-css && yarn min-css",
+    "post-css": "yarn purge-css && yarn min-css && yarn min-css-standalone",
     "purge-css": "purgecss --config ./purgecss.config.js",
-    "min-css": "cleancss dist/quickstarts.css -o dist/quickstarts.min.css"
+    "min-css": "cleancss dist/quickstarts.css -o dist/quickstarts.min.css",
+    "min-css-standalone": "cleancss -o dist/quickstarts-standalone.min.css dist/patternfly-nested.css dist/quickstarts-standalone.css"
   },
   "peerDependencies": {
     "@patternfly/react-core": ">=4.115.2",

--- a/packages/module/purgecss.config.js
+++ b/packages/module/purgecss.config.js
@@ -5,7 +5,12 @@
 
 module.exports = {
   content: ['dist/quickstarts-full.es.js'],
-  css: ['dist/quickstarts-vendor.css', 'dist/patternfly-global.css', 'dist/patternfly-nested.css'],
+  css: [
+    'dist/quickstarts-vendor.css',
+    'dist/patternfly-global.css',
+    'dist/patternfly-nested.css',
+    'dist/quickstarts-standalone.css',
+  ],
   fontFace: false,
   keyframes: true,
   variables: false,

--- a/packages/module/purgecss.config.js
+++ b/packages/module/purgecss.config.js
@@ -5,7 +5,7 @@
 
 module.exports = {
   content: ['dist/quickstarts-full.es.js'],
-  css: ['dist/quickstarts-vendor.css'],
+  css: ['dist/quickstarts-vendor.css', 'dist/patternfly-global.css', 'dist/patternfly-nested.css'],
   fontFace: false,
   keyframes: true,
   variables: false,

--- a/packages/module/rollup.config.js
+++ b/packages/module/rollup.config.js
@@ -7,7 +7,6 @@ import typescript from 'rollup-plugin-typescript2';
 import visualizer from 'rollup-plugin-visualizer';
 import packageJson from './package.json';
 import scss from 'rollup-plugin-scss';
-// import copy from 'rollup-plugin-copy';
 
 const globImporter = require('node-sass-glob-importer');
 
@@ -134,9 +133,6 @@ export const pfStyles = {
     scss({
       output: 'dist/patternfly-nested.css',
       ...commonScssOptions,
-      // processor: css => {
-      //   return css.replace(':root', '.pfext-quick-start__base');
-      // },
     }),
   ],
 };
@@ -150,9 +146,6 @@ export const pfGlobalStyles = {
       output: 'dist/patternfly-global.css',
       ...commonScssOptions,
     }),
-    // copy({
-    //   targets: [{ src: 'node_modules/@patternfly/patternfly/assets', dest: 'dist' }],
-    // }),
   ],
 };
 

--- a/packages/module/rollup.config.js
+++ b/packages/module/rollup.config.js
@@ -7,7 +7,7 @@ import typescript from 'rollup-plugin-typescript2';
 import visualizer from 'rollup-plugin-visualizer';
 import packageJson from './package.json';
 import scss from 'rollup-plugin-scss';
-import copy from 'rollup-plugin-copy';
+// import copy from 'rollup-plugin-copy';
 
 const globImporter = require('node-sass-glob-importer');
 
@@ -134,9 +134,9 @@ export const pfStyles = {
     scss({
       output: 'dist/patternfly-nested.css',
       ...commonScssOptions,
-      processor: css => {
-        return css.replace(':root', '.pfext-quick-start__base');
-      },
+      // processor: css => {
+      //   return css.replace(':root', '.pfext-quick-start__base');
+      // },
     }),
   ],
 };
@@ -149,12 +149,6 @@ export const pfGlobalStyles = {
     scss({
       output: 'dist/patternfly-global.css',
       ...commonScssOptions,
-      processor: css => {
-        console.log(css);
-        console.log('\n--------------------------------------\n')
-        return css;
-        // return css.replace('/*date*/', '/* ' + new Date().toJSON() + ' */');
-      },
     }),
     // copy({
     //   targets: [{ src: 'node_modules/@patternfly/patternfly/assets', dest: 'dist' }],

--- a/packages/module/src/ConsoleShared/src/components/markdown-extensions/MarkdownCopyClipboard.tsx
+++ b/packages/module/src/ConsoleShared/src/components/markdown-extensions/MarkdownCopyClipboard.tsx
@@ -51,12 +51,14 @@ export const CopyClipboard: React.FC<CopyClipboardProps> = ({
       isVisible
       reference={() => element as HTMLElement}
       content={getResource('Successfully copied to clipboard!')}
+      className="pfext-quick-start__base"
     />
   ) : (
     <Tooltip
       key="before-copy"
       reference={() => element as HTMLElement}
       content={getResource('Copy to clipboard')}
+      className="pfext-quick-start__base"
     />
   );
 };

--- a/packages/module/src/ConsoleShared/src/components/popper/SimplePopper.tsx
+++ b/packages/module/src/ConsoleShared/src/components/popper/SimplePopper.tsx
@@ -76,7 +76,11 @@ const SimplePopper: React.FC = ({ children }) => {
 
   return isOpen ? (
     <Portal>
-      <div ref={nodeRefCallback} style={{ zIndex: 9999, position: 'absolute', top: 0, left: 0 }}>
+      <div
+        ref={nodeRefCallback}
+        style={{ zIndex: 9999, position: 'absolute', top: 0, left: 0 }}
+        className="pfext-quick-start__base"
+      >
         {children}
       </div>
     </Portal>

--- a/packages/module/src/QuickStartCatalogPage.tsx
+++ b/packages/module/src/QuickStartCatalogPage.tsx
@@ -154,7 +154,7 @@ export const QuickStartCatalogPage: React.FC<QuickStartCatalogPageProps> = ({
   }
 
   return (
-    <>
+    <div className="pfext-quick-start__base">
       {showTitle && (
         <div className="pfext-page-layout__header">
           <Text component="h1" className="pfext-page-layout__title" data-test="page-title">
@@ -181,6 +181,6 @@ export const QuickStartCatalogPage: React.FC<QuickStartCatalogPageProps> = ({
           <QuickStartCatalog quickStarts={filteredQuickStarts} />
         )}
       </>
-    </>
+    </div>
   );
 };

--- a/packages/module/src/QuickStartCloseModal.tsx
+++ b/packages/module/src/QuickStartCloseModal.tsx
@@ -17,7 +17,7 @@ const QuickStartCloseModal: React.FC<QuickStartCloseModalProps> = ({
   const { getResource } = React.useContext<QuickStartContextValues>(QuickStartContext);
   return (
     <Modal
-      className="pfext-quick-start-drawer__modal"
+      className="pfext-quick-start-drawer__modal pfext-quick-start__base"
       isOpen={isOpen}
       variant={ModalVariant.small}
       showClose={false}

--- a/packages/module/src/QuickStartDrawer.tsx
+++ b/packages/module/src/QuickStartDrawer.tsx
@@ -240,7 +240,7 @@ export const QuickStartDrawer: React.FC<QuickStartDrawerProps> = ({
     <>
       <Drawer isExpanded={!!activeQuickStartID} isInline {...props}>
         {children ? (
-          <DrawerContent className="qsExtRoot" panelContent={panelContent} {...fullWidthBodyStyle}>
+          <DrawerContent panelContent={panelContent} {...fullWidthBodyStyle}>
             <DrawerContentBody className="pfext-quick-start-drawer__body">
               {children}
             </DrawerContentBody>

--- a/packages/module/src/QuickStartDrawer.tsx
+++ b/packages/module/src/QuickStartDrawer.tsx
@@ -240,7 +240,7 @@ export const QuickStartDrawer: React.FC<QuickStartDrawerProps> = ({
     <>
       <Drawer isExpanded={!!activeQuickStartID} isInline {...props}>
         {children ? (
-          <DrawerContent panelContent={panelContent} {...fullWidthBodyStyle}>
+          <DrawerContent className="qsExtRoot" panelContent={panelContent} {...fullWidthBodyStyle}>
             <DrawerContentBody className="pfext-quick-start-drawer__body">
               {children}
             </DrawerContentBody>

--- a/packages/module/src/QuickStartPanelContent.tsx
+++ b/packages/module/src/QuickStartPanelContent.tsx
@@ -86,7 +86,7 @@ const QuickStartPanelContent: React.FC<QuickStartPanelContentProps> = ({
   const content = quickStart ? (
     <DrawerPanelContent
       isResizable={isResizable}
-      className="pfext-quick-start-panel-content"
+      className={css('pfext-quick-start-panel-content', 'pfext-quick-start__base')}
       data-testid={`qs-drawer-${camelize(quickStart.spec.displayName)}`}
       data-qs={`qs-step-${getStep()}`}
       data-test="quickstart drawer"

--- a/packages/module/src/QuickStartPanelContent.tsx
+++ b/packages/module/src/QuickStartPanelContent.tsx
@@ -86,7 +86,7 @@ const QuickStartPanelContent: React.FC<QuickStartPanelContentProps> = ({
   const content = quickStart ? (
     <DrawerPanelContent
       isResizable={isResizable}
-      className={css('pfext-quick-start-panel-content', 'pfext-quick-start__base')}
+      className="pfext-quick-start__base"
       data-testid={`qs-drawer-${camelize(quickStart.spec.displayName)}`}
       data-qs={`qs-step-${getStep()}`}
       data-test="quickstart drawer"

--- a/packages/module/src/catalog/QuickStartCatalog.tsx
+++ b/packages/module/src/catalog/QuickStartCatalog.tsx
@@ -17,7 +17,7 @@ const QuickStartCatalog: React.FC<QuickStartCatalogProps> = ({ quickStarts }) =>
   );
 
   return (
-    <div className="pfext-page-layout__content pfext-is-dark pfext-quick-start__base">
+    <div className="pfext-page-layout__content pfext-is-dark">
       <Gallery className="pfext-quick-start-catalog__gallery" hasGutter>
         {quickStarts.map((quickStart) => {
           const {

--- a/packages/module/src/catalog/QuickStartCatalog.tsx
+++ b/packages/module/src/catalog/QuickStartCatalog.tsx
@@ -17,7 +17,7 @@ const QuickStartCatalog: React.FC<QuickStartCatalogProps> = ({ quickStarts }) =>
   );
 
   return (
-    <div className="pfext-page-layout__content pfext-is-dark">
+    <div className="pfext-page-layout__content pfext-is-dark pfext-quick-start__base">
       <Gallery className="pfext-quick-start-catalog__gallery" hasGutter>
         {quickStarts.map((quickStart) => {
           const {

--- a/packages/module/src/catalog/QuickStartTileDescription.tsx
+++ b/packages/module/src/catalog/QuickStartTileDescription.tsx
@@ -40,19 +40,21 @@ const QuickStartTileDescription: React.FC<QuickStartTileDescriptionProps> = ({
           <Popover
             aria-label={getResource('Prerequisites')}
             headerContent={getResource('Prerequisites')}
-            className="pfext-page-layout__base pfext-quick-start__base"
+            className="pfext-quick-start__base"
             bodyContent={
-              <TextList
-                aria-label={getResource('Prerequisites')}
-                className="pfext-quick-start-tile-prerequisites-list"
-              >
-                {prereqs.map((prerequisite, index) => (
-                  // eslint-disable-next-line react/no-array-index-key
-                  <TextListItem key={index}>
-                    <QuickStartMarkdownView content={prerequisite} />
-                  </TextListItem>
-                ))}
-              </TextList>
+              <div className="pfext-popover__base">
+                <TextList
+                  aria-label={getResource('Prerequisites')}
+                  className="pfext-quick-start-tile-prerequisites-list"
+                >
+                  {prereqs.map((prerequisite, index) => (
+                    // eslint-disable-next-line react/no-array-index-key
+                    <TextListItem key={index}>
+                      <QuickStartMarkdownView content={prerequisite} />
+                    </TextListItem>
+                  ))}
+                </TextList>
+              </div>
             }
           >
             <Button

--- a/packages/module/src/catalog/QuickStartTileDescription.tsx
+++ b/packages/module/src/catalog/QuickStartTileDescription.tsx
@@ -40,7 +40,7 @@ const QuickStartTileDescription: React.FC<QuickStartTileDescriptionProps> = ({
           <Popover
             aria-label={getResource('Prerequisites')}
             headerContent={getResource('Prerequisites')}
-            className="pfext-page-layout__base"
+            className="pfext-page-layout__base pfext-quick-start__base"
             bodyContent={
               <TextList
                 aria-label={getResource('Prerequisites')}

--- a/packages/module/src/controller/QuickStartContent.scss
+++ b/packages/module/src/controller/QuickStartContent.scss
@@ -1,5 +1,3 @@
-// @import 'bootstrap-sass/assets/stylesheets/bootstrap/variables';
-
 .pfext-quick-start-content {
   flex: 1 1 0;
   overflow: auto;

--- a/packages/module/src/controller/QuickStartContent.scss
+++ b/packages/module/src/controller/QuickStartContent.scss
@@ -1,4 +1,4 @@
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/variables';
+// @import '~bootstrap-sass/assets/stylesheets/bootstrap/variables';
 
 .pfext-quick-start-content {
   flex: 1 1 0;

--- a/packages/module/src/controller/QuickStartContent.scss
+++ b/packages/module/src/controller/QuickStartContent.scss
@@ -1,4 +1,4 @@
-// @import '~bootstrap-sass/assets/stylesheets/bootstrap/variables';
+// @import 'bootstrap-sass/assets/stylesheets/bootstrap/variables';
 
 .pfext-quick-start-content {
   flex: 1 1 0;

--- a/packages/module/src/styles/_base.scss
+++ b/packages/module/src/styles/_base.scss
@@ -1,6 +1,6 @@
 // Base element styles.
 // Please DO NOT add rules of this type.
-.pfext-quick-start-panel-content {
+.pfext-quick-start-panel-content__body {
   dl {
     margin: 0px; }
 
@@ -30,11 +30,12 @@
 }
 
 // drawer
-.pfext-quick-start-panel-content,
+.pfext-quick-start-panel-content__header,
+.pfext-quick-start-panel-content__body,
 // catalog gallery wrapper
 .pfext-page-layout__content,
 // catalog item prereq popover
-.pfext-page-layout__base {
+.pfext-popover__base {
   --pf-global--FontSize--md: 14px;
   --pf-global--FontSize--sm: 13px;
 

--- a/packages/module/src/styles/legacy-bootstrap/README.md
+++ b/packages/module/src/styles/legacy-bootstrap/README.md
@@ -7,14 +7,14 @@ Before we had a dependency on bootstrap-sass and pulled in several of their styl
 ```
 .pfext-markdown-view {
   @import './ConsoleInternal/style/vars';
-  @import '~patternfly/dist/sass/patternfly/variables';
-  @import '~bootstrap-sass/assets/stylesheets/bootstrap/variables';
-  @import '~bootstrap-sass/assets/stylesheets/bootstrap/mixins';
-  @import '~patternfly/dist/sass/patternfly/bootstrap-mixin-overrides';
+  @import 'patternfly/dist/sass/patternfly/variables';
+  @import 'bootstrap-sass/assets/stylesheets/bootstrap/variables';
+  @import 'bootstrap-sass/assets/stylesheets/bootstrap/mixins';
+  @import 'patternfly/dist/sass/patternfly/bootstrap-mixin-overrides';
 
-  @import '~bootstrap-sass/assets/stylesheets/bootstrap/type';
-  @import '~bootstrap-sass/assets/stylesheets/bootstrap/code';
-  @import '~bootstrap-sass/assets/stylesheets/bootstrap/tables';
+  @import 'bootstrap-sass/assets/stylesheets/bootstrap/type';
+  @import 'bootstrap-sass/assets/stylesheets/bootstrap/code';
+  @import 'bootstrap-sass/assets/stylesheets/bootstrap/tables';
 }
 ```
 

--- a/packages/module/src/styles/patternfly-global-entry.ts
+++ b/packages/module/src/styles/patternfly-global-entry.ts
@@ -1,0 +1,1 @@
+import './patternfly-global.scss';

--- a/packages/module/src/styles/patternfly-global.scss
+++ b/packages/module/src/styles/patternfly-global.scss
@@ -1,10 +1,23 @@
 // pulls in the patternfly drawer styles, in case the consumer does not have them
 // which can happen when they're not using PatternFly, or a different (older) version
 
-@import '~@patternfly/patternfly/sass-utilities/all';
-@import "~@patternfly/patternfly/components/Drawer/drawer.scss";
-@import "~@patternfly/patternfly/components/Popover/popover.scss";
+@import '@patternfly/patternfly/sass-utilities/all';
+@import '@patternfly/patternfly/components/Drawer/drawer.scss';
+@import '@patternfly/patternfly/components/Popover/popover.scss';
 
-@import "~@patternfly/patternfly/components/ModalBox/modal-box.scss";
-@import "~@patternfly/patternfly/components/Backdrop/backdrop.scss";
-@import "~@patternfly/patternfly/layouts/Bullseye/bullseye.scss";
+// for the 'Leave quick start?` modal
+@import '@patternfly/patternfly/components/ModalBox/modal-box.scss';
+@import '@patternfly/patternfly/components/Backdrop/backdrop.scss';
+@import '@patternfly/patternfly/layouts/Bullseye/bullseye.scss';
+
+// for the markdown extension that lets users copy text to clipboard
+@import '@patternfly/patternfly/components/Tooltip/tooltip.scss';
+
+
+// what do we really need to expose globally?
+// class=pf-c-popover pfext-quick-start__base pf-m-right
+// class=pf-c-modal-box pfext-modal pfext-quick-start-drawer__modal pfext-quick-start__base pf-m-sm
+// class=pf-c-backdrop__open
+// class=pf-c-backdrop
+// class=pf-l-bullseye
+// class=pf-c-tooltip pf-m-top pfext-quick-start__base

--- a/packages/module/src/styles/patternfly-global.scss
+++ b/packages/module/src/styles/patternfly-global.scss
@@ -1,7 +1,21 @@
 // pulls in the patternfly drawer styles, in case the consumer does not have them
 // which can happen when they're not using PatternFly, or a different (older) version
+// some global styles that quickstarts uses (Drawer, Popover, Modal, Backdrop, Bullseye)
+
+// TODO: Investigate if we can remove and/or nest these within patternfly-nested.css
+// what do we really need to expose globally?
+// here are the classes that exist outside the scope of .pfext-quick-start__base:
+// class="pf-c-popover pfext-quick-start__base pf-m-right"
+// class="pf-c-modal-box pfext-modal pfext-quick-start-drawer__modal pfext-quick-start__base pf-m-sm"
+// class="pf-c-backdrop__open"
+// class="pf-c-backdrop"
+// class="pf-l-bullseye"
+// class="pf-c-tooltip pf-m-top pfext-quick-start__base"
 
 @import '@patternfly/patternfly/sass-utilities/all';
+// gets added globally to :root
+@import '@patternfly/patternfly/base/variables';
+
 @import '@patternfly/patternfly/components/Drawer/drawer.scss';
 @import '@patternfly/patternfly/components/Popover/popover.scss';
 
@@ -12,12 +26,3 @@
 
 // for the markdown extension that lets users copy text to clipboard
 @import '@patternfly/patternfly/components/Tooltip/tooltip.scss';
-
-
-// what do we really need to expose globally?
-// class=pf-c-popover pfext-quick-start__base pf-m-right
-// class=pf-c-modal-box pfext-modal pfext-quick-start-drawer__modal pfext-quick-start__base pf-m-sm
-// class=pf-c-backdrop__open
-// class=pf-c-backdrop
-// class=pf-l-bullseye
-// class=pf-c-tooltip pf-m-top pfext-quick-start__base

--- a/packages/module/src/styles/patternfly-global.scss
+++ b/packages/module/src/styles/patternfly-global.scss
@@ -1,0 +1,10 @@
+// pulls in the patternfly drawer styles, in case the consumer does not have them
+// which can happen when they're not using PatternFly, or a different (older) version
+
+@import '~@patternfly/patternfly/sass-utilities/all';
+@import "~@patternfly/patternfly/components/Drawer/drawer.scss";
+@import "~@patternfly/patternfly/components/Popover/popover.scss";
+
+@import "~@patternfly/patternfly/components/ModalBox/modal-box.scss";
+@import "~@patternfly/patternfly/components/Backdrop/backdrop.scss";
+@import "~@patternfly/patternfly/layouts/Bullseye/bullseye.scss";

--- a/packages/module/src/styles/patternfly-nested-entry.ts
+++ b/packages/module/src/styles/patternfly-nested-entry.ts
@@ -1,0 +1,1 @@
+import './patternfly-nested.scss';

--- a/packages/module/src/styles/patternfly-nested.scss
+++ b/packages/module/src/styles/patternfly-nested.scss
@@ -1,0 +1,28 @@
+// pulls in the patternfly styles, in case the consumer does not have them
+// which can happen when they're not using PatternFly, or a different (older) version
+// that could be incompatible with the version of PatternFly that we're using
+
+@import '~@patternfly/patternfly/sass-utilities/all';
+// gets added globally to :root
+@import "~@patternfly/patternfly/base/variables";
+
+.pfext-quick-start__base {
+    $pf-global--enable-reset: false;
+    // @import '~@patternfly/patternfly/patternfly-no-reset.scss';
+    // @import "patternfly-base.scss";
+    // @import "~@patternfly/patternfly/sass-utilities/all";
+    // @import "~@patternfly/patternfly/base/variables";
+    // @import "~@patternfly/patternfly/base/fonts";
+    @import "~@patternfly/patternfly/base/base";
+    @import "~@patternfly/patternfly/utilities/Accessibility/accessibility.scss";
+    // .pf-screen-reader {
+    //     @include pf-u-screen-reader; // for use with assistive technologies
+    // }
+    // @import "~@patternfly/patternfly/base/themes";
+    // @import "~@patternfly/patternfly/base/icons";
+    @import "~@patternfly/patternfly/components/all";
+    @import "~@patternfly/patternfly/layouts/all";
+
+    // some apps globally set text-align: center
+    text-align: left;
+}

--- a/packages/module/src/styles/patternfly-nested.scss
+++ b/packages/module/src/styles/patternfly-nested.scss
@@ -2,26 +2,26 @@
 // which can happen when they're not using PatternFly, or a different (older) version
 // that could be incompatible with the version of PatternFly that we're using
 
-@import '~@patternfly/patternfly/sass-utilities/all';
+@import '@patternfly/patternfly/sass-utilities/all';
 // gets added globally to :root
-@import "~@patternfly/patternfly/base/variables";
+@import '@patternfly/patternfly/base/variables';
 
 .pfext-quick-start__base {
     $pf-global--enable-reset: false;
-    // @import '~@patternfly/patternfly/patternfly-no-reset.scss';
-    // @import "patternfly-base.scss";
-    // @import "~@patternfly/patternfly/sass-utilities/all";
-    // @import "~@patternfly/patternfly/base/variables";
-    // @import "~@patternfly/patternfly/base/fonts";
-    @import "~@patternfly/patternfly/base/base";
-    @import "~@patternfly/patternfly/utilities/Accessibility/accessibility.scss";
+    // @import '@patternfly/patternfly/patternfly-no-reset.scss';
+    // @import 'patternfly-base.scss';
+    // @import '@patternfly/patternfly/sass-utilities/all';
+    // @import '@patternfly/patternfly/base/variables';
+    // @import '@patternfly/patternfly/base/fonts';
+    @import '@patternfly/patternfly/base/base';
+    @import '@patternfly/patternfly/utilities/Accessibility/accessibility.scss';
     // .pf-screen-reader {
     //     @include pf-u-screen-reader; // for use with assistive technologies
     // }
-    // @import "~@patternfly/patternfly/base/themes";
-    // @import "~@patternfly/patternfly/base/icons";
-    @import "~@patternfly/patternfly/components/all";
-    @import "~@patternfly/patternfly/layouts/all";
+    // @import '@patternfly/patternfly/base/themes';
+    // @import '@patternfly/patternfly/base/icons';
+    @import '@patternfly/patternfly/components/all';
+    @import '@patternfly/patternfly/layouts/all';
 
     // some apps globally set text-align: center
     text-align: left;

--- a/packages/module/src/styles/patternfly-nested.scss
+++ b/packages/module/src/styles/patternfly-nested.scss
@@ -3,23 +3,13 @@
 // that could be incompatible with the version of PatternFly that we're using
 
 @import '@patternfly/patternfly/sass-utilities/all';
-// gets added globally to :root
-@import '@patternfly/patternfly/base/variables';
 
 .pfext-quick-start__base {
     $pf-global--enable-reset: false;
-    // @import '@patternfly/patternfly/patternfly-no-reset.scss';
-    // @import 'patternfly-base.scss';
-    // @import '@patternfly/patternfly/sass-utilities/all';
-    // @import '@patternfly/patternfly/base/variables';
-    // @import '@patternfly/patternfly/base/fonts';
-    @import '@patternfly/patternfly/base/base';
+    @import '@patternfly/patternfly/base/common';
     @import '@patternfly/patternfly/utilities/Accessibility/accessibility.scss';
-    // .pf-screen-reader {
-    //     @include pf-u-screen-reader; // for use with assistive technologies
-    // }
-    // @import '@patternfly/patternfly/base/themes';
-    // @import '@patternfly/patternfly/base/icons';
+
+    // it's okay that we include everything since we'll purge the unused styles
     @import '@patternfly/patternfly/components/all';
     @import '@patternfly/patternfly/layouts/all';
 

--- a/packages/module/src/styles/quickstarts-standalone-entry.ts
+++ b/packages/module/src/styles/quickstarts-standalone-entry.ts
@@ -1,0 +1,1 @@
+import './quickstarts-standalone.scss';

--- a/packages/module/src/styles/quickstarts-standalone.scss
+++ b/packages/module/src/styles/quickstarts-standalone.scss
@@ -1,4 +1,7 @@
 .pfext-quick-start__base {
-    @import "../catalog/**/*.scss";
-    @import "../controller/**/*.scss";
+    @import './style.scss';
+    @import '../*.scss';
+    @import '../catalog/**/*.scss';
+    @import '../controller/**/*.scss';
+    @import './vendor.scss';
 }

--- a/packages/module/src/styles/quickstarts-standalone.scss
+++ b/packages/module/src/styles/quickstarts-standalone.scss
@@ -1,0 +1,4 @@
+.pfext-quick-start__base {
+    @import "../catalog/**/*.scss";
+    @import "../controller/**/*.scss";
+}

--- a/packages/module/src/styles/style.scss
+++ b/packages/module/src/styles/style.scss
@@ -1,13 +1,11 @@
-@import '~@patternfly/patternfly/sass-utilities/all';
+@import '@patternfly/patternfly/sass-utilities/all';
 @import './legacy-bootstrap/variables';
 
 @import './base';
 
 // React Components
-@import '../ConsoleInternal/components/icon-and-text';
-@import '../ConsoleInternal/components/catalog/catalog';
-@import '../ConsoleInternal/components/utils/status-box';
-@import '../ConsoleShared/src/components/layout/PageLayout.scss';
+@import '../ConsoleInternal/**/*.scss';
+@import '../ConsoleShared/**/*.scss';
 
 // legacy bootstrap typography styles for markdown content
 @import './legacy-bootstrap.scss';

--- a/packages/module/src/styles/vendor.scss
+++ b/packages/module/src/styles/vendor.scss
@@ -1,7 +1,7 @@
 // be careful about adding additional stylesheets here, they are bundled into the quickstarts.css
 
-@import '~@patternfly/patternfly/sass-utilities/all';
+@import '@patternfly/patternfly/sass-utilities/all';
 
-@import '~@patternfly/react-catalog-view-extension/dist/sass/react-catalog-view-extension.scss';
-@import '~@patternfly/patternfly/components/ClipboardCopy/clipboard-copy.scss';
-@import '~@patternfly/patternfly/components/CodeBlock/code-block.scss';
+@import '@patternfly/react-catalog-view-extension/dist/sass/react-catalog-view-extension.scss';
+@import '@patternfly/patternfly/components/ClipboardCopy/clipboard-copy.scss';
+@import '@patternfly/patternfly/components/CodeBlock/code-block.scss';

--- a/packages/transform-adoc/src/react-converter/util.scss
+++ b/packages/transform-adoc/src/react-converter/util.scss
@@ -1,4 +1,5 @@
-.task-pflist {
+.pfext-quick-start__base {
+  .task-pflist {
     &-title {
       font-size: 14px !important;
       margin-bottom: 6px;
@@ -63,3 +64,4 @@
       }
     }
   }
+}

--- a/snapshots.js
+++ b/snapshots.js
@@ -8,7 +8,7 @@ const runThroughQuickStart = async (id, page, percySnapshot) => {
   };
   await page.goto(`http://localhost:3000?quickstart=${id}`);
   // ensure the page has loaded before capturing a snapshot
-  await page.waitFor('.pf-c-drawer__panel.pfext-quick-start-panel-content');
+  await page.waitFor('.pf-c-drawer__panel');
   withSnapshots && (await percySnapshot(`${id}__intro`, snapshotOptions));
 
   await page.click('[data-test="Start button"]');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2766,6 +2766,14 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
+camel-case@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-3.0.0.tgz#ca3c3688a4e9cf3a4cda777dc4dcbc713249cf73"
+  integrity sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=
+  dependencies:
+    no-case "^2.2.0"
+    upper-case "^1.1.1"
+
 camel-case@^4.1.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-4.1.2.tgz#9728072a954f805228225a6deea6b38461e1bd5a"
@@ -2867,6 +2875,30 @@ chalk@^4.0.0, chalk@^4.1.0:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+change-case@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/change-case/-/change-case-3.1.0.tgz#0e611b7edc9952df2e8513b27b42de72647dd17e"
+  integrity sha512-2AZp7uJZbYEzRPsFoa+ijKdvp9zsrnnt6+yFokfwEpeJm0xuJDVoxiRCAaTzyJND8GJkofo2IcKWaUZ/OECVzw==
+  dependencies:
+    camel-case "^3.0.0"
+    constant-case "^2.0.0"
+    dot-case "^2.1.0"
+    header-case "^1.0.0"
+    is-lower-case "^1.1.0"
+    is-upper-case "^1.1.0"
+    lower-case "^1.1.1"
+    lower-case-first "^1.0.0"
+    no-case "^2.3.2"
+    param-case "^2.1.0"
+    pascal-case "^2.0.0"
+    path-case "^2.1.0"
+    sentence-case "^2.1.0"
+    snake-case "^2.1.0"
+    swap-case "^1.1.0"
+    title-case "^2.1.0"
+    upper-case "^1.1.1"
+    upper-case-first "^1.1.0"
 
 chardet@^0.7.0:
   version "0.7.0"
@@ -3437,6 +3469,14 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
+constant-case@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/constant-case/-/constant-case-2.0.0.tgz#4175764d389d3fa9c8ecd29186ed6005243b6a46"
+  integrity sha1-QXV2TTidP6nI7NKRhu1gBSQ7akY=
+  dependencies:
+    snake-case "^2.1.0"
+    upper-case "^1.1.1"
+
 constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
@@ -3671,6 +3711,14 @@ css-loader@^5.0.0, css-loader@^5.0.2:
     schema-utils "^3.0.0"
     semver "^7.3.5"
 
+css-node-extract@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/css-node-extract/-/css-node-extract-2.1.3.tgz#ec388a857b8fdf13fefd94b3da733257162405da"
+  integrity sha512-E7CzbC0I4uAs2dI8mPCVe+K37xuja5kjIugOotpwICFL7vzhmFMAPHvS/MF9gFrmv8DDUANsxrgyT/I3OLukcw==
+  dependencies:
+    change-case "^3.0.1"
+    postcss "^6.0.14"
+
 css-select@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-4.1.3.tgz#a70440f70317f2669118ad74ff105e65849c7067"
@@ -3681,6 +3729,13 @@ css-select@^4.1.3:
     domhandler "^4.2.0"
     domutils "^2.6.0"
     nth-check "^2.0.0"
+
+css-selector-extract@^3.3.6:
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/css-selector-extract/-/css-selector-extract-3.3.6.tgz#5cc670cfeae743015e80faf2d722d7818657e3e5"
+  integrity sha512-bBI8ZJKKyR9iHvxXb4t3E6WTMkis94eINopVg7y2FmmMjLXUVduD7mPEcADi4i9FX4wOypFMFpySX+0keuefxg==
+  dependencies:
+    postcss "^6.0.14"
 
 css-what@^5.0.0, css-what@^5.0.1:
   version "5.0.1"
@@ -4143,6 +4198,13 @@ domutils@^2.5.2, domutils@^2.6.0, domutils@^2.7.0:
     dom-serializer "^1.0.1"
     domelementtype "^2.2.0"
     domhandler "^4.2.0"
+
+dot-case@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/dot-case/-/dot-case-2.1.1.tgz#34dcf37f50a8e93c2b3bca8bb7fb9155c7da3bee"
+  integrity sha1-NNzzf1Co6TwrO8qLt/uRVcfaO+4=
+  dependencies:
+    no-case "^2.2.0"
 
 dot-case@^3.0.4:
   version "3.0.4"
@@ -6122,6 +6184,14 @@ he@^1.1.0, he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+header-case@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/header-case/-/header-case-1.0.1.tgz#9535973197c144b09613cd65d317ef19963bd02d"
+  integrity sha1-lTWXMZfBRLCWE81l0xfvGZY70C0=
+  dependencies:
+    no-case "^2.2.0"
+    upper-case "^1.1.3"
+
 heimdalljs-logger@^0.1.10, heimdalljs-logger@^0.1.7:
   version "0.1.10"
   resolved "https://registry.yarnpkg.com/heimdalljs-logger/-/heimdalljs-logger-0.1.10.tgz#90cad58aabb1590a3c7e640ddc6a4cd3a43faaf7"
@@ -6897,6 +6967,13 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-lower-case@^1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-lower-case/-/is-lower-case-1.1.3.tgz#7e147be4768dc466db3bfb21cc60b31e6ad69393"
+  integrity sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=
+  dependencies:
+    lower-case "^1.1.0"
+
 is-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
@@ -7052,6 +7129,13 @@ is-unc-path@^1.0.0:
   integrity sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==
   dependencies:
     unc-path-regex "^0.1.2"
+
+is-upper-case@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/is-upper-case/-/is-upper-case-1.1.2.tgz#8d0b1fa7e7933a1e58483600ec7d9661cbaf756f"
+  integrity sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=
+  dependencies:
+    upper-case "^1.1.0"
 
 is-utf8@^0.2.0, is-utf8@^0.2.1:
   version "0.2.1"
@@ -8187,6 +8271,18 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+lower-case-first@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/lower-case-first/-/lower-case-first-1.0.2.tgz#e5da7c26f29a7073be02d52bac9980e5922adfa1"
+  integrity sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=
+  dependencies:
+    lower-case "^1.1.2"
+
+lower-case@^1.1.0, lower-case@^1.1.1, lower-case@^1.1.2:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
+  integrity sha1-miyr0bno4K6ZOkv31YdcOcQujqw=
+
 lower-case@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28"
@@ -8937,6 +9033,13 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+no-case@^2.2.0, no-case@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"
+  integrity sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==
+  dependencies:
+    lower-case "^1.1.1"
+
 no-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
@@ -9020,6 +9123,26 @@ node-releases@^1.1.71:
   version "1.1.73"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.73.tgz#dd4e81ddd5277ff846b80b52bb40c49edf7a7b20"
   integrity sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==
+
+node-sass-glob-importer@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/node-sass-glob-importer/-/node-sass-glob-importer-5.3.2.tgz#465581e46027c0e9520e6d87f7e6eda858a14acb"
+  integrity sha512-QTX7KPsISgp55REV6pMH703nzHfWCOEYEQC0cDyTRo7XO6WDvyC0OAzekuQ4gs505IZcxv9KxZ3uPJ5s5H9D3g==
+  dependencies:
+    node-sass-magic-importer "^5.3.2"
+
+node-sass-magic-importer@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/node-sass-magic-importer/-/node-sass-magic-importer-5.3.2.tgz#2f2248bb2e5cdb275ba34102ebf995edadf99175"
+  integrity sha512-T3wTUdUoXQE3QN+EsyPpUXRI1Gj1lEsrySQ9Kzlzi15QGKi+uRa9fmvkcSy2y3BKgoj//7Mt9+s+7p0poMpg6Q==
+  dependencies:
+    css-node-extract "^2.1.3"
+    css-selector-extract "^3.3.6"
+    findup-sync "^3.0.0"
+    glob "^7.1.3"
+    object-hash "^1.3.1"
+    postcss-scss "^2.0.0"
+    resolve "^1.10.1"
 
 node-sass@^6.0.1:
   version "6.0.1"
@@ -9182,6 +9305,11 @@ object-copy@^0.1.0:
     copy-descriptor "^0.1.0"
     define-property "^0.2.5"
     kind-of "^3.0.3"
+
+object-hash@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.1.tgz#fde452098a951cb145f039bb7d455449ddc126df"
+  integrity sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==
 
 object-inspect@^1.10.3, object-inspect@^1.7.0, object-inspect@^1.9.0:
   version "1.10.3"
@@ -9464,6 +9592,13 @@ parallel-transform@^1.1.0:
     inherits "^2.0.3"
     readable-stream "^2.1.5"
 
+param-case@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/param-case/-/param-case-2.1.1.tgz#df94fd8cf6531ecf75e6bef9a0858fbc72be2247"
+  integrity sha1-35T9jPZTHs915r75oIWPvHK+Ikc=
+  dependencies:
+    no-case "^2.2.0"
+
 param-case@^3.0.3:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/param-case/-/param-case-3.0.4.tgz#7d17fe4aa12bde34d4a77d91acfb6219caad01c5"
@@ -9552,6 +9687,14 @@ parseurl@^1.3.2, parseurl@~1.3.2, parseurl@~1.3.3:
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
 
+pascal-case@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-2.0.1.tgz#2d578d3455f660da65eca18ef95b4e0de912761e"
+  integrity sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=
+  dependencies:
+    camel-case "^3.0.0"
+    upper-case-first "^1.1.0"
+
 pascal-case@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-3.1.2.tgz#b48e0ef2b98e205e7c1dae747d0b1508237660eb"
@@ -9577,6 +9720,13 @@ path-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a"
   integrity sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==
+
+path-case@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/path-case/-/path-case-2.1.1.tgz#94b8037c372d3fe2906e465bb45e25d226e8eea5"
+  integrity sha1-lLgDfDctP+KQbkZbtF4l0ibo7qU=
+  dependencies:
+    no-case "^2.2.0"
 
 path-dirname@^1.0.0:
   version "1.0.2"
@@ -9768,6 +9918,11 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
+picocolors@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-0.2.1.tgz#570670f793646851d1ba135996962abad587859f"
+  integrity sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==
+
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.2.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
@@ -9880,6 +10035,13 @@ postcss-modules-values@^4.0.0:
   dependencies:
     icss-utils "^5.0.0"
 
+postcss-scss@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-2.1.1.tgz#ec3a75fa29a55e016b90bf3269026c53c1d2b383"
+  integrity sha512-jQmGnj0hSGLd9RscFw9LyuSVAa5Bl1/KBPqG1NQw9w8ND55nY4ZEsdlVuYJvLPpV+y0nwTV5v/4rHPzZRihQbA==
+  dependencies:
+    postcss "^7.0.6"
+
 postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4:
   version "6.0.6"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz#2c5bba8174ac2f6981ab631a42ab0ee54af332ea"
@@ -9892,6 +10054,23 @@ postcss-value-parser@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
   integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
+
+postcss@^6.0.14:
+  version "6.0.23"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
+  integrity sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==
+  dependencies:
+    chalk "^2.4.1"
+    source-map "^0.6.1"
+    supports-color "^5.4.0"
+
+postcss@^7.0.6:
+  version "7.0.39"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.39.tgz#9624375d965630e2e1f2c02a935c82a59cb48309"
+  integrity sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==
+  dependencies:
+    picocolors "^0.2.1"
+    source-map "^0.6.1"
 
 postcss@^8.2.1, postcss@^8.2.15:
   version "8.3.5"
@@ -11135,6 +11314,14 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
+sentence-case@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/sentence-case/-/sentence-case-2.1.1.tgz#1f6e2dda39c168bf92d13f86d4a918933f667ed4"
+  integrity sha1-H24t2jnBaL+S0T+G1KkYkz9mftQ=
+  dependencies:
+    no-case "^2.2.0"
+    upper-case-first "^1.1.2"
+
 serialize-javascript@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
@@ -11358,6 +11545,13 @@ slice-ansi@^2.1.0:
     ansi-styles "^3.2.0"
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
+
+snake-case@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/snake-case/-/snake-case-2.1.0.tgz#41bdb1b73f30ec66a04d4e2cad1b76387d4d6d9f"
+  integrity sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=
+  dependencies:
+    no-case "^2.2.0"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -11911,6 +12105,14 @@ supports-hyperlinks@^1.0.1:
     has-flag "^2.0.0"
     supports-color "^5.0.0"
 
+swap-case@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/swap-case/-/swap-case-1.1.2.tgz#c39203a4587385fad3c850a0bd1bcafa081974e3"
+  integrity sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=
+  dependencies:
+    lower-case "^1.1.1"
+    upper-case "^1.1.1"
+
 symbol-tree@^3.2.1, symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
@@ -12154,6 +12356,14 @@ tippy.js@5.1.2:
   integrity sha512-Qtrv2wqbRbaKMUb6bWWBQWPayvcDKNrGlvihxtsyowhT7RLGEh1STWuy6EMXC6QLkfKPB2MLnf8W2mzql9VDAw==
   dependencies:
     popper.js "^1.16.0"
+
+title-case@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/title-case/-/title-case-2.1.1.tgz#3e127216da58d2bc5becf137ab91dae3a7cd8faa"
+  integrity sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=
+  dependencies:
+    no-case "^2.2.0"
+    upper-case "^1.0.3"
 
 tmp@^0.0.33:
   version "0.0.33"
@@ -12598,6 +12808,18 @@ update-check@1.5.2:
   dependencies:
     registry-auth-token "3.3.2"
     registry-url "3.1.0"
+
+upper-case-first@^1.1.0, upper-case-first@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/upper-case-first/-/upper-case-first-1.1.2.tgz#5d79bedcff14419518fd2edb0a0507c9b6859115"
+  integrity sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=
+  dependencies:
+    upper-case "^1.1.1"
+
+upper-case@^1.0.3, upper-case@^1.1.0, upper-case@^1.1.1, upper-case@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
+  integrity sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
Creates new stylesheets:
```js
// some global styles and variables that quickstarts uses (Drawer, Popover, Modal, Backdrop, Bullseye)
import '@patternfly/quickstarts/dist/patternfly-global.css';
// PF and quickstarts styles nested within .pfext-quick-start__base
import '@patternfly/quickstarts/dist/quickstarts-standalone.min.css';
```
These are useful if a consumer uses an older version of PatternFly for instance