### PR TITLE
Add configuration to opt-out of new header colors

### DIFF
--- a/packages/module/README.md
+++ b/packages/module/README.md
@@ -110,7 +110,10 @@ const App = () => {
     allQuickStartStates,
     setActiveQuickStartID,
     setAllQuickStartStates,
+    // Set to true to opt-out of default hidden card footers
     showCardFooters: false,
+    // Set to true to opt-out of default drawer header colors of blue with white text
+    useLegacyHeaderColors: false,
     loading,
     useQueryParams: withQueryParams,
   };
@@ -156,6 +159,10 @@ const SomeNestedComponent = () => {
 
 export default App;
 ```
+
+## Design update, option to opt-out of new drawer header coloring
+
+See above usage of `useLegacyHeaderColors` boolean to opt-out of update. Should only be used if new color scheme clashes with the usage context.
 
 ## Quick starts format
 

--- a/packages/module/src/QuickStartDrawer.tsx
+++ b/packages/module/src/QuickStartDrawer.tsx
@@ -36,6 +36,8 @@ export interface QuickStartContainerProps extends React.HTMLProps<HTMLDivElement
   onCloseNotInProgress?: any;
   /* true to show footer buttons in the catalog tiles (default true) */
   showCardFooters?: boolean;
+  /* true to use legacy drawer header variant colors */
+  useLegacyHeaderColors?: boolean;
   /* text resources object */
   resourceBundle?: any;
   /* language of the current resource bundle */
@@ -72,6 +74,7 @@ export const QuickStartContainer: React.FC<QuickStartContainerProps> = ({
   onCloseNotInProgress,
   resourceBundle,
   showCardFooters,
+  useLegacyHeaderColors,
   language,
   loading = false,
   useQueryParams = true,
@@ -89,6 +92,7 @@ export const QuickStartContainer: React.FC<QuickStartContainerProps> = ({
     footer: {
       show: showCardFooters,
     },
+    useLegacyHeaderColors,
     language,
     resourceBundle: {
       ...resourceBundle,
@@ -158,6 +162,7 @@ export const QuickStartDrawer: React.FC<QuickStartDrawerProps> = ({
     activeQuickStartState,
     allQuickStartStates,
     setAllQuickStartStates,
+    useLegacyHeaderColors,
   } = React.useContext<QuickStartContextValues>(QuickStartContext);
   const combinedQuickStarts = allQuickStarts.concat(quickStarts);
 
@@ -232,7 +237,7 @@ export const QuickStartDrawer: React.FC<QuickStartDrawerProps> = ({
       activeQuickStartID={activeQuickStartID}
       appendTo={appendTo}
       isResizable={!fullWidth}
-      headerVariant="blue-white"
+      headerVariant={useLegacyHeaderColors ? '' : 'blue-white'}
       {...fullWidthPanelStyle}
     />
   );

--- a/packages/module/src/utils/quick-start-context.tsx
+++ b/packages/module/src/utils/quick-start-context.tsx
@@ -56,6 +56,7 @@ export type QuickStartContextValues = {
   setQuickStartTaskStatus?: (taskStatus: QuickStartTaskStatus) => void;
   getQuickStartForId?: (id: string) => QuickStartState;
   footer?: FooterProps;
+  useLegacyHeaderColors?: boolean;
   useQueryParams?: boolean;
   markdown?: {
     extensions?: any[];
@@ -99,6 +100,7 @@ export const QuickStartContextDefaults = {
   },
   setFilter: () => {},
   footer: null,
+  useLegacyHeaderColors: false,
   markdown: null,
   loading: false,
   alwaysShowTaskReview: false,
@@ -131,6 +133,7 @@ export const useValuesForQuickStartContext = (
     allQuickStartStates,
     allQuickStarts = [],
     footer,
+    useLegacyHeaderColors,
     markdown,
   } = combinedValue;
   const [quickStarts, setQuickStarts] = React.useState(combinedValue.allQuickStarts || []);
@@ -438,6 +441,7 @@ export const useValuesForQuickStartContext = (
     setQuickStartTaskStatus, // revisit if this should be in public context API
     getQuickStartForId,
     footer,
+    useLegacyHeaderColors,
     useQueryParams,
     markdown,
     resourceBundle,


### PR DESCRIPTION
In the case that a product's UI clashes with drawer header color update to blue with white text:
- default to blue/white
- add boolean option to opt-out of these changes

Closes: #95 