### PR TITLE
Adds language and countryCode keys and creates new localization demo

### DIFF
--- a/packages/dev/src/App3.tsx
+++ b/packages/dev/src/App3.tsx
@@ -1,0 +1,92 @@
+import './App.css';
+import { Page } from '@patternfly/react-core';
+import {
+  LoadingBox,
+  QuickStart,
+  QuickStartContainer,
+  QuickStartContainerProps,
+  useLocalStorage,
+} from '@patternfly/quickstarts';
+import { localizedQuickStarts as yamlQuickStarts } from './quickstarts-data/quick-start-test-data';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { AppHeader, AppSidebar } from './common/Page';
+
+type AppProps = {
+  children?: React.ReactNode;
+  showCardFooters?: boolean;
+};
+
+// filter quickStarts by language (there is also an option to filter by country code)
+const filterByLanguage = (quickStarts: QuickStart[], currentLanguage: string) => {
+  if (currentLanguage !== 'en') {
+    let filtered = quickStarts.filter((qs) => qs.metadata.language === currentLanguage);
+    // if there are no translation for the currentLanguage default to en
+    if (!filtered.length) {
+      filtered = quickStarts.filter((qs) => qs.metadata.language === 'en');
+    }
+    return filtered;
+  }
+  // en
+  // also include quick starts that do not have the locale set
+  return quickStarts.filter(
+    (qs) => qs.metadata.language === currentLanguage || !qs.metadata.language,
+  );
+};
+
+const App3: React.FC<AppProps> = ({ children, showCardFooters }) => {
+  const [activeQuickStartID, setActiveQuickStartID] = useLocalStorage('quickstartId', '');
+  const [allQuickStartStates, setAllQuickStartStates] = useLocalStorage('quickstarts', {});
+  const [loading, setLoading] = React.useState(true);
+
+  const { i18n } = useTranslation();
+
+  // eslint-disable-next-line no-console
+  React.useEffect(() => console.log(activeQuickStartID), [activeQuickStartID]);
+  React.useEffect(() => {
+    // callback on state change
+    // eslint-disable-next-line no-console
+    console.log(allQuickStartStates);
+  }, [allQuickStartStates]);
+
+  const language = localStorage.getItem('bridge/language') || 'en';
+  const resourceBundle = i18n.getResourceBundle(language, 'quickstart');
+
+  const [allQuickStarts, setAllQuickStarts] = React.useState<QuickStart[]>([]);
+  React.useEffect(() => {
+    const load = async () => {
+      setAllQuickStarts(filterByLanguage(yamlQuickStarts, language));
+      setLoading(false);
+    };
+    setTimeout(() => {
+      load();
+    }, 1500);
+  }, [language]);
+
+  const withQueryParams = true;
+
+  const drawerProps: QuickStartContainerProps = {
+    quickStarts: allQuickStarts,
+    activeQuickStartID,
+    allQuickStartStates,
+    setActiveQuickStartID,
+    setAllQuickStartStates,
+    resourceBundle,
+    showCardFooters,
+    language,
+    loading,
+    useQueryParams: withQueryParams,
+    alwaysShowTaskReview: false,
+  };
+
+  return (
+    <React.Suspense fallback={<LoadingBox />}>
+      <QuickStartContainer {...drawerProps}>
+        <Page header={AppHeader} sidebar={AppSidebar} isManagedSidebar>
+          {children}
+        </Page>
+      </QuickStartContainer>
+    </React.Suspense>
+  );
+};
+export default App3;

--- a/packages/dev/src/Demos.ts
+++ b/packages/dev/src/Demos.ts
@@ -25,6 +25,11 @@ export const Demos: DemoInterface[] = [
     name: 'Quick starts prop based',
     to: '/quickstarts-props',
   },
+  {
+    id: 'quickstarts-localized',
+    name: 'Quick starts localized',
+    to: '/quickstarts-localized',
+  },
 ];
 
 export default Demos;

--- a/packages/dev/src/index.tsx
+++ b/packages/dev/src/index.tsx
@@ -49,7 +49,6 @@ ReactDOM.render(
       </Route>
       <Route exact path="/quickstarts-localized">
         <App3 showCardFooters>
-          <SomeNestedComponent />
           <DefaultCatalog />
         </App3>
       </Route>

--- a/packages/dev/src/index.tsx
+++ b/packages/dev/src/index.tsx
@@ -17,6 +17,7 @@ import { Route, BrowserRouter as Router, Switch } from 'react-router-dom';
 import './i18n/i18n';
 import App from './App';
 import App2 from './App2';
+import App3 from './App3';
 import { QuickStartContext } from '@patternfly/quickstarts';
 import { DefaultCatalog } from './DefaultCatalog';
 import { CustomCatalog } from './CustomCatalog';
@@ -45,6 +46,12 @@ ReactDOM.render(
           <SomeNestedComponent />
           <DefaultCatalog />
         </App2>
+      </Route>
+      <Route exact path="/quickstarts-localized">
+        <App3 showCardFooters>
+          <SomeNestedComponent />
+          <DefaultCatalog />
+        </App3>
       </Route>
       <Route exact path="/custom-catalog">
         <App showCardFooters>

--- a/packages/dev/src/quickstarts-data/localized-data/cs/demo.yaml
+++ b/packages/dev/src/quickstarts-data/localized-data/cs/demo.yaml
@@ -1,0 +1,37 @@
+metadata:
+  name: demo
+  language: cs
+  countryCode: CZ
+spec:
+  displayName: Quick starts demo
+  durationMinutes: 5
+  icon: ''
+  description: V tomto demu si ukážeme, co quick start umí.
+  introduction: |-
+    ### V tomto demu si ukážeme, co quick start umí.
+  tasks:
+    - title: Zvýraznění-Highligting (yaml+markdown)
+      description: |-
+        1. Použitím atributu `data-quickstart-id` můžete zvýraznit prvky.
+          
+          **Příklad**
+
+          ```data-quickstart-id="highlight-me"```
+        1. Z quick startu, se zvýraznění použije díky markdownu takto:
+          
+          **Příklad**
+
+          `Highlight [my element]{{highlight highlight-me}}`
+        1. Dva příklady:
+          - [Highlight quick starts nav item]{{highlight Dashboard}}
+          - [Highlight reload button]{{highlight reload-qs}}
+      review:
+        instructions: |-
+          #### K ověření:
+          Vidíte zvýrazněné prvky?
+        failedTaskHelp: Tento úkol ještě nebyl ověřen. Zkuste to znovu.
+      summary:
+        success: Teď už umíte vytvořit zvýrazněné prvky.
+        failed: Zkuste kroky zopakovat.
+  conclusion: Demo je dokončené.
+  nextQuickStart: []

--- a/packages/dev/src/quickstarts-data/localized-data/en/demo.yaml
+++ b/packages/dev/src/quickstarts-data/localized-data/en/demo.yaml
@@ -1,0 +1,36 @@
+metadata:
+  name: demo
+  language: en
+spec:
+  displayName: Quick starts demo
+  durationMinutes: 5
+  icon: ''
+  description: This demo will walk you through quick start features
+  introduction: |-
+    ### This demo will walk you through quick start features
+  tasks:
+    - title: Highlighting (yaml+markdown)
+      description: |-
+        1. You can highlight elements by assigning a `data-quickstart-id` attribute. 
+          
+          **Example**
+
+          ```data-quickstart-id="highlight-me"```
+        1. From within the quick start, you can trigger that by by writing markdown such as:
+          
+          **Example**
+
+          `Highlight [my element]{{highlight highlight-me}}`
+        1. Two examples:
+          - [Highlight quick starts nav item]{{highlight quickstarts}}
+          - [Highlight reload button]{{highlight reload-qs}}
+      review:
+        instructions: |-
+          #### To verify:
+          Did you see the elements highlighted?
+        failedTaskHelp: This task isn’t verified yet. Try the task again.
+      summary:
+        success: You have learned about highlighting elements!
+        failed: Try the steps again.
+  conclusion: You have finished the quick starts features overview
+  nextQuickStart: []

--- a/packages/dev/src/quickstarts-data/quick-start-test-data.ts
+++ b/packages/dev/src/quickstarts-data/quick-start-test-data.ts
@@ -22,6 +22,9 @@ import serverlessApplicationQuickstart from './mocks/yamls/serverless-applicatio
 import springWithS2i from './mocks/yamls/spring-with-s2i.yaml';
 import copyExecuteSnippet from './mocks/yamls/copy-execute-snippets.yaml';
 
+import csDemo from './localized-data/cs/demo.yaml';
+import enDemo from './localized-data/en/demo.yaml';
+
 // import addHealthchecksQuickstartADoc from "raw-loader!./mocks/asciidoc/add-healthchecks-quickstart.adoc";
 // import template from "raw-loader!./mocks/asciidoc/TEMPLATE_PROCEDURE.adoc";
 import sampleA from 'raw-loader!./mocks/asciidoc/business-central-editing-data-sources-proc.adoc';
@@ -106,4 +109,9 @@ export const allQuickStarts: QuickStart[] = [
   // }),
   // ProcQuickStartParser(masGettingStarted),
   // ProcQuickStartParser(masKafkaBinScripts)
+];
+
+export const localizedQuickStarts: QuickStart[] = [
+  csDemo,
+  enDemo
 ];

--- a/packages/module/README.md
+++ b/packages/module/README.md
@@ -250,4 +250,6 @@ return (
 Use this [file](https://github.com/patternfly/patternfly-quickstarts/blob/main/packages/module/src/locales/en/quickstart.json) as a base for your translations.
 Each language is different, especially when it comes to plurals. Try [this utility](https://jsfiddle.net/6bpxsgd4) sourced from [i18next](https://www.i18next.com/translation-function/plurals#how-to-find-the-correct-plural-suffix) to determine the suffixes for the right plural format.
 
+For localizing the content of quick starts files, we provide the option to include `language` and `countryCode` key to your translated file. Based on these keys you can filter out quick starts. We have a demo of this behaviour in our [demo app](https://quickstarts.netlify.app/). You can have a look at the code [here](https://github.com/patternfly/patternfly-quickstarts/blob/main/packages/dev/src/App3.tsx).
+
 #### 

--- a/packages/module/src/ConsoleInternal/module/k8s/types.ts
+++ b/packages/module/src/ConsoleInternal/module/k8s/types.ts
@@ -27,6 +27,7 @@ export type OwnerReference = {
 };
 
 export type ObjectMetadata = {
+  name: string;
   annotations?: { [key: string]: string };
   clusterName?: string;
   creationTimestamp?: string;
@@ -37,11 +38,16 @@ export type ObjectMetadata = {
   generation?: number;
   labels?: { [key: string]: string };
   managedFields?: any[];
-  name?: string;
   namespace?: string;
   ownerReferences?: OwnerReference[];
   resourceVersion?: string;
   uid?: string;
+  // language can be: en
   language?: string;
-  countryCode?: string;
+  // country can be: US
+  country?: string;
+  // locale is a combination of language and country, for example: en_US
+  locale?: string;
+  // anything else to custom define
+  [key: string]: any;
 };

--- a/packages/module/src/ConsoleInternal/module/k8s/types.ts
+++ b/packages/module/src/ConsoleInternal/module/k8s/types.ts
@@ -42,4 +42,6 @@ export type ObjectMetadata = {
   ownerReferences?: OwnerReference[];
   resourceVersion?: string;
   uid?: string;
+  language?: string;
+  countryCode?: string;
 };

--- a/packages/module/src/QuickStartCatalogPage.tsx
+++ b/packages/module/src/QuickStartCatalogPage.tsx
@@ -93,7 +93,11 @@ export const QuickStartCatalogPage: React.FC<QuickStartCatalogPageProps> = ({
           allQuickStartStates,
         ).sort(sortFncCallback)
       : allQuickStarts;
-    if (filteredQs.length !== filteredQuickStarts.length) {
+    // also needs a check whether the content of the QS changed
+    if (
+      filteredQs.length !== filteredQuickStarts.length ||
+      JSON.stringify(filteredQs) !== JSON.stringify(filteredQuickStarts)
+    ) {
       setFilteredQuickStarts(filteredQs);
     }
   }, [


### PR DESCRIPTION
Closes #93 

So I didn't put the filtering based on the language inside the library. We are gonna leave it for the consumer, they can filter it how they want it (more flexibility).
I added a new demo under /quickstart-localized to demonstrate how it can be done.