### PR TITLE
Export catalog page props.

### DIFF
--- a/packages/module/src/QuickStartCatalogPage.tsx
+++ b/packages/module/src/QuickStartCatalogPage.tsx
@@ -17,7 +17,7 @@ import { QuickStartContext, QuickStartContextValues } from './utils/quick-start-
 import { QuickStart } from './utils/quick-start-types';
 import { filterQuickStarts } from './utils/quick-start-utils';
 
-type QuickStartCatalogPageProps = {
+export type QuickStartCatalogPageProps = {
   quickStarts?: QuickStart[];
   showFilter?: boolean;
   sortFnc?: (q1: QuickStart, q2: QuickStart) => number;


### PR DESCRIPTION
We require the catalog page props in some of the chrome integration work when providing the API to the micro frontends.

cc @jschuler @CooperRedhat 