### PR TITLE
optional duration

### DIFF
--- a/packages/module/src/QuickStartPanelContent.tsx
+++ b/packages/module/src/QuickStartPanelContent.tsx
@@ -106,10 +106,14 @@ const QuickStartPanelContent: React.FC<QuickStartPanelContentProps> = ({
             >
               {quickStart?.spec.displayName}{' '}
               <small className="pfext-quick-start-panel-content__duration">
-                {getResource(
-                  'Quick start • {{duration, number}} minutes',
-                  quickStart?.spec.durationMinutes,
-                ).replace('{{duration, number}}', quickStart?.spec.durationMinutes)}
+                {quickStart?.spec.durationMinutes
+                  ? getResource(
+                      '{{type}} • {{duration, number}} minutes',
+                      quickStart?.spec.durationMinutes,
+                    )
+                      .replace('{{duration, number}}', quickStart?.spec.durationMinutes)
+                      .replace('{{type}}', getResource('Type'))
+                  : getResource('Type')}
               </small>
             </Title>
           </div>

--- a/packages/module/src/locales/en/quickstart.json
+++ b/packages/module/src/locales/en/quickstart.json
@@ -41,5 +41,6 @@
   "Not available": "Not available",
   "Copy to clipboard": "Copy to clipboard",
   "Successfully copied to clipboard!": "Successfully copied to clipboard!",
-  "Quick start • {{duration, number}} minutes": "Quick start • {{duration, number}} minutes"
+  "Type": "Quick start",
+  "{{type}} • {{duration, number}} minutes": "{{type}} • {{duration, number}} minutes"
 }


### PR DESCRIPTION
Closes https://github.com/patternfly/patternfly-quickstarts/issues/109

Default:
![Screen Shot 2022-01-24 at 12 46 48 PM](https://user-images.githubusercontent.com/869106/150836793-1f2f38fc-4b13-4f92-a13d-d871968c9416.png)

No durationMinutes:
![Screen Shot 2022-01-24 at 12 47 07 PM](https://user-images.githubusercontent.com/869106/150836829-5dd50451-2f4d-4b98-a8e7-b080151b090e.png)

When overriding the `Type` resource:
```
resourceBundle: {
      ...resourceBundle,
      Type: 'Documentation',
    },
```
![Screen Shot 2022-01-24 at 12 47 35 PM](https://user-images.githubusercontent.com/869106/150836897-3a722a7b-db5d-4595-a8f2-846e22ad95e4.png)

When overriding the `Type` resource and not specifying durationMinutes:
![Screen Shot 2022-01-24 at 12 47 47 PM](https://user-images.githubusercontent.com/869106/150836952-62d3c051-07c9-43cc-9168-ff71313950af.png)


