### PR TITLE
support all admonitions, concat description blocks

### DIFF
--- a/packages/dev/src/quickstarts-data/asciidoc/alert-note-prereq/README.adoc
+++ b/packages/dev/src/quickstarts-data/asciidoc/alert-note-prereq/README.adoc
@@ -35,6 +35,52 @@ IMPORTANT: I am an Alert (aka IMPORTANT in asciidoc) rendered by Patternfly Reac
 . Do you see a note section?
 . Do you see an alert section and task-level prerequisites?.
 
+
+[id="proc-description-with-admonition-blocks_{context}"]
+== Note, important, warning, etc sections in description
+
+After you create a service accounts for applications to connect to a {registry} instance, you must also set the appropriate level of access for the new account in the *Access* tab of the {registry} instance. {registry} uses role-based access to enable you to manage how other user accounts and service accounts can interact with the {registry} instance that you create.
+
+Note:
+
+NOTE: If you want to use a service account that already has the required role, you  can skip this section.
+
+Tip:
+
+TIP: If you want to use a service account that already has the required role, you can skip this section.
+
+Important:
+
+IMPORTANT: If you want to use a service account that already has the required role, you can skip this section.
+
+Caution:
+
+CAUTION: If you want to use a service account that already has the required role, you can skip this section.
+
+Warning:
+
+WARNING: If you want to use a service account that already has the required role, you can skip this section.
+
+.Prerequisites
+* You've created a {registry} instance and the instance is in *Ready* state.
+* You've created a service account that you want to allow to access the running {registry} instance.
+
+.Procedure
+. In the *{registry} Instances* page of the web console, click the name of the {registry} instance that you want the service account to access.
+. Click the *Access* tab to view the accounts and roles already assigned for this instance.
+. Click *Grant access* to assign a role to the service account.
+. In the *Account* field, select or enter the service account name that you want to assign the role to.
+. Select the *Role* that you want to assign to the account, for example, *Manager* for write access to this instance.
+. Click *Save* to finish.
+
+.Verification
+ifdef::qs[]
+* Is the new role for the service account listed in the *Access* page of the {registry} instance?
+endif::[]
+ifndef::qs[]
+* Verify that the new role for the service account is listed in the *Access* page of the {registry} instance.
+endif::[]
+
 [#conclusion]
 Congratulations! You successfully completed the example quick start, and are now aware of the new features.
 

--- a/packages/dev/src/quickstarts-data/asciidoc/alert-note-prereq/README.adoc
+++ b/packages/dev/src/quickstarts-data/asciidoc/alert-note-prereq/README.adoc
@@ -1,5 +1,5 @@
 [id="chap-alert-note-prereq"]
-= Alert, note, and prerequisites example quickstart
+= Note/Tip card, 3 alert variants and prerequisites example quickstart
 
 .Prerequisites
 * You want to see some new features condensed into one example quickstart.
@@ -13,33 +13,46 @@ Welcome to this example quickstart making it easy to see some new features, whic
 endif::[]
 
 [id="task-1_{context}",module-type="proc"]
-== Look at the new features
+== Prerequisites expanded, note, tip, and 3 alert variants in procedure
 
 In this Quick Start you will preview some design changes.
 
 .Prerequisites
 * Take a look at the new design changes, including this prerequisites section.
-* Also take a look at the note and alert sections.
+* Also take a look at the note, tip, and 3 types of alerts renderd by PF React.
 
 .Procedure
-. Note section
+. Note
 +
-NOTE: I am a Note rendered by Patternfly React Components.
+NOTE: I am a note card (triggerd by NOTE admonition in asciidoc) rendered by Patternfly React Components.
 +
 
-. Alert section
+. Tip
 +
-IMPORTANT: I am an Alert (aka IMPORTANT in asciidoc) rendered by Patternfly React Components.
+TIP: I am a tip card (triggerd by TIP admonition in asciidoc) rendered by Patternfly React Components.
++
+
+. Info
++
+IMPORTANT: I am an info alert (triggerd by IMPORTANT admonition in asciidoc) rendered by Patternfly React Components.
++
+
+. Warning
++
+CAUTION: I am a warning alert (triggerd by CAUTION admonition in asciidoc) rendered by Patternfly React Components.
++
+
+. Danger
++
+WARNING: I am a danger alert (triggerd by WARNING admonition in asciidoc) rendered by Patternfly React Components.
 
 .Verification
-. Do you see a note section?
-. Do you see an alert section and task-level prerequisites?.
+. Do you see a note and info card?
+. Do you see 3 types of alerts and task-level prerequisites?
 
 
 [id="proc-description-with-admonition-blocks_{context}"]
-== Note, important, warning, etc sections in description
-
-After you create a service accounts for applications to connect to a {registry} instance, you must also set the appropriate level of access for the new account in the *Access* tab of the {registry} instance. {registry} uses role-based access to enable you to manage how other user accounts and service accounts can interact with the {registry} instance that you create.
+== Note, tip and 3 alert variants in task description
 
 Note:
 
@@ -62,24 +75,13 @@ Warning:
 WARNING: If you want to use a service account that already has the required role, you can skip this section.
 
 .Prerequisites
-* You've created a {registry} instance and the instance is in *Ready* state.
-* You've created a service account that you want to allow to access the running {registry} instance.
+* Review at description above
 
 .Procedure
-. In the *{registry} Instances* page of the web console, click the name of the {registry} instance that you want the service account to access.
-. Click the *Access* tab to view the accounts and roles already assigned for this instance.
-. Click *Grant access* to assign a role to the service account.
-. In the *Account* field, select or enter the service account name that you want to assign the role to.
-. Select the *Role* that you want to assign to the account, for example, *Manager* for write access to this instance.
-. Click *Save* to finish.
+. No steps for this task
 
 .Verification
-ifdef::qs[]
-* Is the new role for the service account listed in the *Access* page of the {registry} instance?
-endif::[]
-ifndef::qs[]
-* Verify that the new role for the service account is listed in the *Access* page of the {registry} instance.
-endif::[]
+* Did you see the sections above?
 
 [#conclusion]
 Congratulations! You successfully completed the example quick start, and are now aware of the new features.

--- a/packages/dev/src/quickstarts-data/asciidoc/alert-note-prereq/README.adoc
+++ b/packages/dev/src/quickstarts-data/asciidoc/alert-note-prereq/README.adoc
@@ -56,7 +56,7 @@ WARNING: I am a danger alert (triggerd by WARNING admonition in asciidoc) render
 
 Note:
 
-NOTE: If you want to use a service account that already has the required role, you  can skip this section.
+NOTE: If you'd like to use a service account that already has the required role, you  can skip this section.
 
 Tip:
 

--- a/packages/dev/src/quickstarts-data/asciidoc/alert-note-prereq/quickstart.yml
+++ b/packages/dev/src/quickstarts-data/asciidoc/alert-note-prereq/quickstart.yml
@@ -4,7 +4,7 @@ metadata:
 spec:
   displayName: !snippet/title README.adoc#chap-alert-note-prereq
   durationMinutes: 2
-  type: 
+  type:
     text: AsciiDoc
     color: purple
   icon: data:image/svg+xml;base64,PCEtLSBHZW5lcmF0ZWQgYnkgSWNvTW9vbi5pbyAtLT4KPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjUxMiIgaGVpZ2h0PSI1MTIiIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj4KPHRpdGxlPjwvdGl0bGU+CjxnIGlkPSJpY29tb29uLWlnbm9yZSI+CjwvZz4KPHBhdGggZD0iTTQ0OCA2NHY0MTZoLTMzNmMtMjYuNTEzIDAtNDgtMjEuNDktNDgtNDhzMjEuNDg3LTQ4IDQ4LTQ4aDMwNHYtMzg0aC0zMjBjLTM1LjE5OSAwLTY0IDI4LjgtNjQgNjR2Mzg0YzAgMzUuMiAyOC44MDEgNjQgNjQgNjRoMzg0di00NDhoLTMyeiI+PC9wYXRoPgo8cGF0aCBkPSJNMTEyLjAyOCA0MTZ2MGMtMC4wMDkgMC4wMDEtMC4wMTkgMC0wLjAyOCAwLTguODM2IDAtMTYgNy4xNjMtMTYgMTZzNy4xNjQgMTYgMTYgMTZjMC4wMDkgMCAwLjAxOS0wLjAwMSAwLjAyOC0wLjAwMXYwLjAwMWgzMDMuOTQ1di0zMmgtMzAzLjk0NXoiPjwvcGF0aD4KPC9zdmc+Cg==
@@ -16,6 +16,7 @@ spec:
   introduction: !snippet README.adoc#introduction
   tasks:
     - !snippet/proc README.adoc#task-1
+    - !snippet/proc README.adoc#proc-description-with-admonition-blocks
   conclusion: !snippet README.adoc#conclusion
   nextQuickStart:
     - 'kafka-bin-scripts'

--- a/packages/dev/src/quickstarts-data/asciidoc/procedure-parser.ts
+++ b/packages/dev/src/quickstarts-data/asciidoc/procedure-parser.ts
@@ -29,7 +29,7 @@ export const ProcQuickStartParser = (
       delete task.proc;
     }
 
-    let description,
+    let description = '',
       procedure,
       verification,
       title,
@@ -59,8 +59,8 @@ export const ProcQuickStartParser = (
           /**
           child typically looks like:
 
-          <div class="paragraph|olist|ulist">
-             <div class="title">Procedure|Prerequisites|Verification</div>
+          <div class="paragraph|olist|ulist|admonitionblock">
+             <div class="title">Procedure|Prerequisites|Verification|Note|Warning</div>
              <ol|ul class="arabic">
                <li>
                <li>...
@@ -74,8 +74,13 @@ export const ProcQuickStartParser = (
           const child = sectionBody.children.item(i);
           // find the title
           const sectionTitle = child?.querySelector('.heading,.title');
-          if (sectionTitle) {
-            switch (sectionTitle?.textContent?.trim()) {
+          // should this section be assigned to a specific section
+          const sectionTitleText = sectionTitle?.textContent?.trim();
+          const isKnownSection = ['Procedure', 'Verification', 'Prerequisites'].includes(
+            sectionTitle?.textContent?.trim(),
+          );
+          if (isKnownSection) {
+            switch (sectionTitleText) {
               case 'Procedure':
                 procedure = child?.querySelector(':not(.heading):not(.title)')?.outerHTML.trim();
                 break;
@@ -90,7 +95,7 @@ export const ProcQuickStartParser = (
             }
           } else if (!procedure) {
             // Otherwise if it comes before a procedure it's part of the description
-            description = child?.innerHTML.trim();
+            description = description + child?.outerHTML.trim();
           }
         }
       }

--- a/packages/transform-adoc/src/react-converter/add-react-converter.tsx
+++ b/packages/transform-adoc/src/react-converter/add-react-converter.tsx
@@ -1,15 +1,10 @@
 import { Asciidoctor } from 'asciidoctor';
 import {
-  isCautionBlock,
-  isImportantBlock,
-  isNoteBlock,
+  isAdmonitionBlock,
   isTaskLevelPrereqs,
   isTaskLevelProcedure,
-  isTipBlock,
-  isWarningBlock,
-  renderPFImportant,
+  renderAdmonitionBlock,
   renderPFList,
-  renderPFNote,
 } from './util';
 
 export const addReactConverter = (asciidoctor: Asciidoctor) => {
@@ -17,16 +12,10 @@ export const addReactConverter = (asciidoctor: Asciidoctor) => {
     baseConverter = asciidoctor.Html5Converter.create();
 
     convert(node: Asciidoctor.AbstractBlock, transform: string) {
-      if (isNoteBlock(node) || isTipBlock(node)) {
-        return renderPFNote(node as Asciidoctor.AbstractBlock, false);
+      if (isAdmonitionBlock(node)) {
+        return renderAdmonitionBlock(node as Asciidoctor.AbstractBlock, false);
       }
-      if (isImportantBlock(node) || isCautionBlock(node) || isWarningBlock(node)) {
-        return renderPFImportant(node as Asciidoctor.AbstractBlock, false);
-      }
-      if (isTaskLevelPrereqs(node)) {
-        return renderPFList(node as Asciidoctor.List);
-      }
-      if (isTaskLevelProcedure(node)) {
+      if (isTaskLevelPrereqs(node) || isTaskLevelProcedure(node)) {
         return renderPFList(node as Asciidoctor.List);
       }
       return this.baseConverter.convert(node, transform);

--- a/packages/transform-adoc/src/react-converter/add-react-converter.tsx
+++ b/packages/transform-adoc/src/react-converter/add-react-converter.tsx
@@ -1,11 +1,28 @@
 import { Asciidoctor } from 'asciidoctor';
-import { isTaskLevelPrereqs, isTaskLevelProcedure, renderPFList } from './util';
+import {
+  isCautionBlock,
+  isImportantBlock,
+  isNoteBlock,
+  isTaskLevelPrereqs,
+  isTaskLevelProcedure,
+  isTipBlock,
+  isWarningBlock,
+  renderPFImportant,
+  renderPFList,
+  renderPFNote,
+} from './util';
 
 export const addReactConverter = (asciidoctor: Asciidoctor) => {
   class ReactConverter {
     baseConverter = asciidoctor.Html5Converter.create();
 
     convert(node: Asciidoctor.AbstractBlock, transform: string) {
+      if (isNoteBlock(node) || isTipBlock(node)) {
+        return renderPFNote(node as Asciidoctor.AbstractBlock, false);
+      }
+      if (isImportantBlock(node) || isCautionBlock(node) || isWarningBlock(node)) {
+        return renderPFImportant(node as Asciidoctor.AbstractBlock, false);
+      }
       if (isTaskLevelPrereqs(node)) {
         return renderPFList(node as Asciidoctor.List);
       }

--- a/packages/transform-adoc/src/react-converter/util.scss
+++ b/packages/transform-adoc/src/react-converter/util.scss
@@ -64,4 +64,30 @@
       }
     }
   }
+  .description-note {
+    background-color: var(--pf-global--palette--blue-50);
+    border-color: var(--pf-global--active-color--200);
+    margin: var(--pf-global--spacer--md) 0;
+    &__body {
+      font-size: 14px;
+    }
+  }
+  .description-important {
+    &.pf-c-alert {
+      // add margins to match design
+      margin: var(--pf-global--spacer--md) 0;
+      .pf-c-alert__title {
+        // remove margins from markdown css
+        margin-top: 0;
+        margin-bottom: 0;
+        // lift PF style specificity to override markdown css
+        font-weight: var(--pf-c-alert__title--FontWeight);
+        font-family: inherit;
+        line-height: inherit;
+        color: var(--pf-c-alert__title--Color);
+        word-break: break-word;
+      }
+    }
+
+  }
 }

--- a/packages/transform-adoc/src/react-converter/util.tsx
+++ b/packages/transform-adoc/src/react-converter/util.tsx
@@ -10,6 +10,9 @@ const PREREQUISITES = 'Prerequisites';
 const PROCEDURE = 'Procedure';
 const IMPORTANT = 'IMPORTANT';
 const NOTE = 'NOTE';
+const WARNING = 'WARNING';
+const TIP = 'TIP';
+const CAUTION = 'CAUTION';
 
 export const getModuleType = (node: Asciidoctor.AbstractNode) => {
   if (node.getAttributes()[MODULE_TYPE_ATTRIBUTE]) {
@@ -52,21 +55,60 @@ export const isNoteBlock = (node: Asciidoctor.AbstractBlock) => {
   return node.getAttribute('style') === NOTE;
 };
 
+export const isWarningBlock = (node: Asciidoctor.AbstractBlock) => {
+  return node.getAttribute('style') === WARNING;
+};
+
+export const isTipBlock = (node: Asciidoctor.AbstractBlock) => {
+  return node.getAttribute('style') === TIP;
+};
+
+export const isCautionBlock = (node: Asciidoctor.AbstractBlock) => {
+  return node.getAttribute('style') === CAUTION;
+};
+
 export const renderMarkup = (component: React.ReactElement) => {
   return ReactDOMServer.renderToStaticMarkup(component);
 };
 
-export const renderPFImportant = (node: Asciidoctor.AbstractBlock) => {
-  const inlineWarningAlert = <Alert variant="warning" isInline title={node.getContent()} />;
+export const renderPFImportant = (node: Asciidoctor.AbstractBlock, inList: boolean) => {
+  const inlineWarningAlert = (
+    <Alert
+      variant="warning"
+      isInline
+      title={node.getContent()}
+      className={css(!inList && 'description-important')}
+    />
+  );
   // Don't render to markup yet, will be passed through by parent
   return ReactDOMServer.renderToString(inlineWarningAlert);
 };
 
-export const renderPFNote = (node: Asciidoctor.AbstractBlock) => {
+export const renderPFNote = (node: Asciidoctor.AbstractBlock, inList: boolean = false) => {
   const noteTitle = (node.getAttribute && node.getAttribute('textlabel')) || 'Note';
+  const classNames = {
+    inList: {
+      card: 'task-pflist-list__item__content__note',
+      cardBody: 'task-pflist-list__item__content__note__body',
+    },
+    inDescription: {
+      card: 'description-note',
+      cardBody: 'description-note__body',
+    },
+  };
   const note = (
-    <Card isPlain isFlat isCompact className="task-pflist-list__item__content__note">
-      <CardBody className="task-pflist-list__item__content__note__body">
+    <Card
+      isPlain
+      isFlat
+      isCompact
+      className={css(inList && classNames.inList.card, !inList && classNames.inDescription.card)}
+    >
+      <CardBody
+        className={css(
+          inList && classNames.inList.cardBody,
+          !inList && classNames.inDescription.cardBody,
+        )}
+      >
         <strong>{noteTitle}:</strong> {node.getContent()}
       </CardBody>
     </Card>
@@ -85,11 +127,11 @@ export const getListTexts = (list: Asciidoctor.List) => {
       return isNoteBlock(block);
     });
     if (importantBlock) {
-      const importantRendered = renderPFImportant(importantBlock);
+      const importantRendered = renderPFImportant(importantBlock, true);
       return listItem.setText(listItem.getText() + importantRendered);
     }
     if (noteBlock) {
-      const noteRendered = renderPFNote(noteBlock);
+      const noteRendered = renderPFNote(noteBlock, true);
       return listItem.setText(listItem.getText() + noteRendered);
     }
     return listItem.getText();


### PR DESCRIPTION
Closes #105 

Also solves issue where only the final newline separated string (or `.adoc` block) was rendered in description.