### PR TITLE
[HelpTopics] Styling, hamburger menu, close behavior example, etc.

### DIFF
--- a/packages/dev/src/MockConsole.tsx
+++ b/packages/dev/src/MockConsole.tsx
@@ -54,7 +54,7 @@ const FormGroupWithHelpTopicPopover: React.FC<FormGroupWithHelpTopicPopoverProps
                     hide();
                   }}
                 >
-                  Learn more
+                  Learn more!
                 </Button>
               </div>
             )}

--- a/packages/dev/src/MockConsole.tsx
+++ b/packages/dev/src/MockConsole.tsx
@@ -9,6 +9,7 @@ import {
   Popover,
   Split,
   SplitItem,
+  Switch,
   TextInput,
   Title,
 } from '@patternfly/react-core';
@@ -41,26 +42,32 @@ const FormGroupWithHelpTopicPopover: React.FC<FormGroupWithHelpTopicPopoverProps
       fieldId={topic.name}
       key={topic.name}
       labelIcon={
-        <Popover
-          bodyContent={(hide) => (
-            <div>
-              {topic.title} is quite amaizing{' '}
-              <Button
-                variant="link"
-                onClick={() => {
-                  setActiveHelpTopicByName(topic.name);
-                  hide();
-                }}
-              >
-                Learn more
-              </Button>
-            </div>
-          )}
-        >
-          <Button variant="plain">
-            <HelpIcon noVerticalAlign />
-          </Button>
-        </Popover>
+        <>
+          <Popover
+            bodyContent={(hide) => (
+              <div>
+                {topic.title} is quite amaizing{' '}
+                <Button
+                  variant="link"
+                  onClick={() => {
+                    setActiveHelpTopicByName(topic.name);
+                    hide();
+                  }}
+                >
+                  Learn more
+                </Button>
+              </div>
+            )}
+          >
+            <Button variant="plain">
+              <HelpIcon noVerticalAlign />
+            </Button>
+          </Popover>
+          <Button
+            variant="link"
+            onClick={() => setActiveHelpTopicByName(topic.name)}
+          >{`Learn more about ${topic.title}`}</Button>
+        </>
       }
     >
       <TextInput isRequired type="text" id={topic.name} />
@@ -76,12 +83,14 @@ export const MockConsole: React.FC = () => {
     setActiveHelpTopicByName,
   } = React.useContext<HelpTopicContextValues>(HelpTopicContext);
 
+  const [closeDrawerOnPageChange, setCloseDrawerOnPageChange] = React.useState(true);
+
   // mock console page identifiers: 1 - 6
   // click handlers to change page
   const [consolePageState, setConsolePageState] = React.useState(1);
 
   const handleClickNext = () => {
-    setActiveHelpTopicByName('');
+    closeDrawerOnPageChange && setActiveHelpTopicByName('');
     if (consolePageState === 6) {
       setConsolePageState(1);
       return;
@@ -90,14 +99,13 @@ export const MockConsole: React.FC = () => {
   };
 
   const handleClickBack = () => {
-    setActiveHelpTopicByName('');
+    closeDrawerOnPageChange && setActiveHelpTopicByName('');
     if (consolePageState === 6) {
       setConsolePageState(4);
       return;
     }
     setConsolePageState(consolePageState - 1);
   };
-
   // Example usage setFilteredHelpTopics()
   // After rendering the console, set the filtered help topics
   React.useEffect(() => {
@@ -147,14 +155,16 @@ export const MockConsole: React.FC = () => {
       </PageSection>
       <PageSection>
         <Title headingLevel="h3">
-          Example usage of help topics opened via popover{' '}
-          <b>
-            {consolePageState < 4
-              ? 'using tags that match the Console Page number'
-              : 'by defining which help topics should be present on each page'}
-          </b>
+          Example usage of help topics opened via popover and directly from a link{' '}
+          <div>
+            <b>
+              {consolePageState < 4
+                ? 'Using tags that match the Console Page number'
+                : 'By defining which help topics should be present on each page'}
+            </b>
+          </div>
         </Title>
-        <Divider />
+        <Divider style={{ padding: '20px 0px' }} />
         <Form>
           {consolePageState < 4
             ? formGroupsFromTags
@@ -170,6 +180,14 @@ export const MockConsole: React.FC = () => {
           </SplitItem>
           <SplitItem>
             <Button onClick={handleClickNext}>Next</Button>
+          </SplitItem>
+          <SplitItem>
+            <Switch
+              label="Close drawer on page change"
+              labelOff="DON'T close drawer on page change"
+              isChecked={closeDrawerOnPageChange}
+              onChange={() => setCloseDrawerOnPageChange(!closeDrawerOnPageChange)}
+            />
           </SplitItem>
         </Split>
       </PageSection>

--- a/packages/module/src/HelpTopicDrawer.tsx
+++ b/packages/module/src/HelpTopicDrawer.tsx
@@ -85,9 +85,9 @@ export const HelpTopicDrawer: React.FC<HelpTopicDrawerProps> = ({
   children,
   ...props
 }) => {
-  const { activeHelpTopic, filteredHelpTopics } = React.useContext<HelpTopicContextValues>(
-    HelpTopicContext,
-  );
+  const { activeHelpTopic, filteredHelpTopics, setActiveHelpTopicByName } = React.useContext<
+    HelpTopicContextValues
+  >(HelpTopicContext);
 
   // Leave here if query param is desired for help topics later
   // React.useEffect(() => {
@@ -100,10 +100,15 @@ export const HelpTopicDrawer: React.FC<HelpTopicDrawerProps> = ({
   //   }
   // }, [inContextHelpTopics, setActiveHelpTopicByName]);
 
+  const onClose = () => {
+    setActiveHelpTopicByName('');
+  };
+
   const panelContent = (
     <HelpTopicPanelContent
       activeHelpTopic={activeHelpTopic}
       filteredHelpTopics={filteredHelpTopics}
+      onClose={onClose}
     />
   );
 

--- a/packages/module/src/HelpTopicDrawer.tsx
+++ b/packages/module/src/HelpTopicDrawer.tsx
@@ -63,6 +63,15 @@ export const HelpTopicContainer: React.FC<HelpTopicContainerProps> = ({
     }
   }, [loading, valuesForHelpTopicContext]);
 
+  React.useEffect(() => {
+    if (
+      helpTopics &&
+      JSON.stringify(helpTopics) !== JSON.stringify(valuesForHelpTopicContext.helpTopics)
+    ) {
+      valuesForHelpTopicContext.setHelpTopics(helpTopics);
+    }
+  }, [helpTopics, valuesForHelpTopicContext]);
+
   const drawerProps = {
     //TODO add extras here?
     ...props,

--- a/packages/module/src/HelpTopicPanelContent.tsx
+++ b/packages/module/src/HelpTopicPanelContent.tsx
@@ -49,13 +49,15 @@ const HelpTopicPanelContent: React.FC<HelpTopicPanelContentProps> = ({
     toggleHelpTopicMenu();
   };
 
-  const menuItems = filteredHelpTopics.map((topic) => {
-    return (
-      <OptionsMenuItem key={topic.name} onSelect={onSelectHelpTopic} id={topic.name}>
-        {topic.title}
-      </OptionsMenuItem>
-    );
-  });
+  const menuItems =
+    filteredHelpTopics.length > 0 &&
+    filteredHelpTopics.map((topic) => {
+      return (
+        <OptionsMenuItem key={topic.name} onSelect={onSelectHelpTopic} id={topic.name}>
+          {topic.title}
+        </OptionsMenuItem>
+      );
+    });
 
   const paddingContainer = (children) => <div style={{ padding: '24px' }}>{children}</div>;
 
@@ -76,19 +78,21 @@ const HelpTopicPanelContent: React.FC<HelpTopicPanelContentProps> = ({
       <div>
         <DrawerHead>
           <div className="pfext-quick-start-panel-content__title">
-            <OptionsMenu
-              id={'helptopics'}
-              isPlain
-              isOpen={isHelpTopicMenuOpen}
-              toggle={
-                <OptionsMenuToggle
-                  style={{ paddingLeft: '0px' }}
-                  onToggle={toggleHelpTopicMenu}
-                  toggleTemplate={<BarsIcon />}
-                />
-              }
-              menuItems={menuItems}
-            />
+            {menuItems && (
+              <OptionsMenu
+                id={'helptopics'}
+                isPlain
+                isOpen={isHelpTopicMenuOpen}
+                toggle={
+                  <OptionsMenuToggle
+                    style={{ paddingLeft: '0px' }}
+                    onToggle={toggleHelpTopicMenu}
+                    toggleTemplate={<BarsIcon />}
+                  />
+                }
+                menuItems={menuItems}
+              />
+            )}
 
             <Title
               headingLevel="h1"

--- a/packages/module/src/HelpTopicPanelContent.tsx
+++ b/packages/module/src/HelpTopicPanelContent.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import {
   Divider,
+  DrawerActions,
+  DrawerCloseButton,
   // DrawerActions,
   // DrawerCloseButton,
   DrawerHead,
@@ -9,8 +11,6 @@ import {
   OptionsMenu,
   OptionsMenuItem,
   OptionsMenuToggle,
-  Stack,
-  StackItem,
   Title,
 } from '@patternfly/react-core';
 // import { css } from '@patternfly/react-styles';
@@ -25,12 +25,14 @@ type HelpTopicPanelContentProps = {
   activeHelpTopic: HelpTopic;
   filteredHelpTopics?: HelpTopic[];
   isResizable?: boolean;
+  onClose: () => void;
 };
 
 const HelpTopicPanelContent: React.FC<HelpTopicPanelContentProps> = ({
   activeHelpTopic = null,
   filteredHelpTopics = [],
   isResizable = true,
+  onClose,
   ...props
 }) => {
   const { setActiveHelpTopicByName } = React.useContext<HelpTopicContextValues>(HelpTopicContext);
@@ -55,6 +57,20 @@ const HelpTopicPanelContent: React.FC<HelpTopicPanelContentProps> = ({
     );
   });
 
+  const paddingContainer = (children) => <div style={{ padding: '24px' }}>{children}</div>;
+
+  const panelBodyItems = (
+    <>
+      {paddingContainer(<QuickStartMarkdownView content={activeHelpTopic?.content} />)}
+      <Divider />
+      {paddingContainer(
+        activeHelpTopic?.links.map((link) => {
+          return <QuickStartMarkdownView key={link} content={link} />;
+        }),
+      )}
+    </>
+  );
+
   const content = (
     <DrawerPanelContent isResizable={isResizable} className="pfext-quick-start__base" {...props}>
       <div>
@@ -65,7 +81,11 @@ const HelpTopicPanelContent: React.FC<HelpTopicPanelContentProps> = ({
               isPlain
               isOpen={isHelpTopicMenuOpen}
               toggle={
-                <OptionsMenuToggle onToggle={toggleHelpTopicMenu} toggleTemplate={<BarsIcon />} />
+                <OptionsMenuToggle
+                  style={{ paddingLeft: '0px' }}
+                  onToggle={toggleHelpTopicMenu}
+                  toggleTemplate={<BarsIcon />}
+                />
               }
               menuItems={menuItems}
             />
@@ -79,15 +99,15 @@ const HelpTopicPanelContent: React.FC<HelpTopicPanelContentProps> = ({
               {activeHelpTopic?.title}
             </Title>
           </div>
-          {/* {showClose && (
+          {
             <DrawerActions>
               <DrawerCloseButton
-                onClick={handleClose}
+                onClick={onClose}
                 className="pfext-quick-start-panel-content__close-button"
                 data-testid="qs-drawer-close"
               />
             </DrawerActions>
-          )} */}
+          }
         </DrawerHead>
         <Divider />
         <DrawerPanelBody
@@ -95,17 +115,7 @@ const HelpTopicPanelContent: React.FC<HelpTopicPanelContentProps> = ({
           className="pfext-quick-start-panel-content__body"
           data-test="content"
         >
-          <Stack hasGutter>
-            <StackItem style={{ padding: '20px' }}>
-              <QuickStartMarkdownView content={activeHelpTopic?.content} />
-            </StackItem>
-            <Divider />
-            <StackItem style={{ padding: '20px' }}>
-              {activeHelpTopic?.links.map((link) => {
-                return <QuickStartMarkdownView key={link} content={link} />;
-              })}
-            </StackItem>
-          </Stack>
+          {panelBodyItems}
         </DrawerPanelBody>
       </div>
     </DrawerPanelContent>

--- a/packages/module/src/utils/help-topic-context.tsx
+++ b/packages/module/src/utils/help-topic-context.tsx
@@ -3,6 +3,7 @@ import { HelpTopic } from './help-topic-types';
 
 export type HelpTopicContextValues = {
   helpTopics?: HelpTopic[];
+  setHelpTopics?: React.Dispatch<React.SetStateAction<HelpTopic[]>>;
   activeHelpTopic?: HelpTopic;
   setActiveHelpTopicByName?: (helpTopicName: string) => void;
   filteredHelpTopics?: HelpTopic[];
@@ -13,6 +14,7 @@ export type HelpTopicContextValues = {
 
 export const HelpTopicContextDefaults = {
   helpTopics: [],
+  setHelpTopics: () => {},
   activeHelpTopic: null,
   setActiveHelpTopicByName: () => {},
   filteredHelpTopics: [],
@@ -35,7 +37,7 @@ export const useValuesForHelpTopicContext = (
   const [loading, setLoading] = React.useState(combinedValue.loading);
 
   // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
-  const [helpTopics, setHelpTopics] = React.useState(combinedValue.helpTopics || []);
+  const [helpTopics, setHelpTopics] = React.useState<HelpTopic[]>(combinedValue.helpTopics || []);
 
   const [activeHelpTopic, setActiveHelpTopic] = React.useState(
     combinedValue.activeHelpTopic || null,
@@ -61,6 +63,7 @@ export const useValuesForHelpTopicContext = (
 
   return {
     helpTopics,
+    setHelpTopics,
     activeHelpTopic,
     setActiveHelpTopicByName,
     filteredHelpTopics,


### PR DESCRIPTION
- Reintroduce close button
- Update styles to align paragraph and title
- Remove hamburger dropdown if filteredHelpTopics not set or empty
- Add example to modify closing behavior
- Auto update HelpTopicContainer when helpTopics change

Closes #149, towards #150 
Closes #151
Closes #154