### PR TITLE
Conditionally access activeHelpTopic links array.

### DIFF
--- a/packages/module/src/HelpTopicPanelContent.tsx
+++ b/packages/module/src/HelpTopicPanelContent.tsx
@@ -69,7 +69,7 @@ const HelpTopicPanelContent: React.FC<HelpTopicPanelContentProps> = ({
       <Divider />
       {paddingContainer(
         <Stack hasGutter>
-          {activeHelpTopic?.links.map(({ href, text, newTab, isExternal }) => {
+          {activeHelpTopic?.links?.map(({ href, text, newTab, isExternal }) => {
             return (
               <StackItem>
                 <Button


### PR DESCRIPTION
If the content does not define the links array, the UI will cause a crash due to an unexpected `map` call.

```
Uncaught TypeError: Cannot read properties of undefined (reading 'map')
    at HelpTopicPanelContent (index.es.js:2358:1)
    at renderWithHooks (react-dom.development.js:14985:1)
    at updateFunctionComponent (react-dom.development.js:17356:1)
    at beginWork (react-dom.development.js:19063:1)
    at HTMLUnknownElement.callCallback (react-dom.development.js:3945:1)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:3994:1)
    at invokeGuardedCallback (react-dom.development.js:4056:1)
    at beginWork$1 (react-dom.development.js:23964:1)
    at performUnitOfWork (react-dom.development.js:22776:1)
    at workLoopSync (react-dom.development.js:22707:1)
```

```js
{activeHelpTopic?.links.map(({ href, text, newTab, isExternal }) => {
```

cc @CooperRedhat @jschuler 
More details in slack conversation. Can we get this released ASAP, please?