### PR TITLE
getResource doesn't shown anything if translation string is missing in the ResourceBundle (incl. English)

### DIFF
--- a/packages/module/src/utils/quick-start-context.tsx
+++ b/packages/module/src/utils/quick-start-context.tsx
@@ -88,7 +88,7 @@ export const QuickStartContextDefaults = {
   activeQuickStartState: {},
   setAllQuickStarts: () => {},
   resourceBundle: en,
-  getResource: () => '',
+  getResource: (resource: string) => resource,
   language: 'en',
   useQueryParams: true,
   filter: {
@@ -115,7 +115,7 @@ export const getResource = (resource: string, options: any, resourceBundle: any,
       return resourceBundle[`${resource}_${suffix}`];
     }
   }
-  return (resourceBundle && resourceBundle[resource]) || '';
+  return (resourceBundle && resourceBundle[resource]) || resource;
 };
 
 export const useValuesForQuickStartContext = (


### PR DESCRIPTION
In the OpenShift Console, we missed some translations in our resource bundle. Also, the English ResourceBundle missed some translations from this package.

In this case, the UI doesn't show _anything_ because `getResource` returns an empty string if the translation isn't found in the ResourceBundle.

In this case, `getResource` should return the input `resource` string instead so that the UI shows _something_. If just the translation is missing it shows at least an English version.