### PR TITLE
show help topic menu when there is more than one help topic

### DIFF
--- a/packages/module/src/HelpTopicPanelContent.tsx
+++ b/packages/module/src/HelpTopicPanelContent.tsx
@@ -52,7 +52,7 @@ const HelpTopicPanelContent: React.FC<HelpTopicPanelContentProps> = ({
   };
 
   const menuItems =
-    filteredHelpTopics.length > 0 &&
+    filteredHelpTopics.length > 1 &&
     filteredHelpTopics.map((topic) => {
       return (
         <OptionsMenuItem key={topic.name} onSelect={onSelectHelpTopic} id={topic.name}>


### PR DESCRIPTION
The help topic panel provides a dropdown menu to switch between topics that are currently available. However if there is only a single topic available, this menu is of no use.

This change removes the menu unless there are 2 or more help topics.

Before:
![image](https://user-images.githubusercontent.com/14068621/229158787-21104737-2c47-47c5-938a-f58ed61c3631.png)

After:
![image](https://user-images.githubusercontent.com/14068621/229159503-9ecc30a0-7473-4260-a8b7-7263bbee009b.png)
