### PR TITLE
Filter fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,6 @@
     "visual": "npx percy exec -- node snapshots.js",
     "test:a11y": "patternfly-a11y --config patternfly-a11y.config"
   },
-  "dependencies": {
-    "@patternfly/react-core": "^4.276.8"
-  },
   "devDependencies": {
     "@patternfly/patternfly-a11y": "^4.3.1",
     "@percy/script": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "visual": "npx percy exec -- node snapshots.js",
     "test:a11y": "patternfly-a11y --config patternfly-a11y.config"
   },
+  "dependencies": {
+    "@patternfly/react-core": "^4.276.8"
+  },
   "devDependencies": {
     "@patternfly/patternfly-a11y": "^4.3.1",
     "@percy/script": "^1.1.0",

--- a/packages/module/package.json
+++ b/packages/module/package.json
@@ -45,7 +45,7 @@
     "docs:copy": "mkdir -p dist/patternfly-docs && cp -R patternfly-docs/content/extensions/quick-starts dist/patternfly-docs"
   },
   "peerDependencies": {
-    "@patternfly/react-core": ">=4.115.2",
+    "@patternfly/react-core": ">=4.276.8",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "showdown": ">=1.8.6"

--- a/packages/module/src/catalog/Toolbar/QuickStartCatalogFilterItems.tsx
+++ b/packages/module/src/catalog/Toolbar/QuickStartCatalogFilterItems.tsx
@@ -72,7 +72,7 @@ interface QuickStartCatalogFilterSearchWrapperProps {
   onSearchInputChange: any;
 }
 export const QuickStartCatalogFilterSearchWrapper: React.FC<QuickStartCatalogFilterSearchWrapperProps> = ({
-  onSearchInputChange = () => {},
+  onSearchInputChange = (val?:string) => {},
 }) => {
   const { useQueryParams, filter, setFilter } = React.useContext<QuickStartContextValues>(
     QuickStartContext,
@@ -91,7 +91,7 @@ export const QuickStartCatalogFilterSearchWrapper: React.FC<QuickStartCatalogFil
       unlisten();
     };
   }, [onSearchInputChange, setFilter]);
-  const handleTextChange = (val: string) => {
+  const handleTextChange = (ev: unknown, val: string) => {
     if (val.length > 0) {
       useQueryParams && setQueryArgument(QUICKSTART_SEARCH_FILTER_KEY, val);
     } else {


### PR DESCRIPTION
Reason for this fix: https://issues.redhat.com/browse/RHCLOUD-25108

There is a workaround in place: https://github.com/RedHatInsights/learning-resources/pull/12/files

There is a breaking change in the latest version of PatternFly (this is why I have added "@patternfly/react-core" to dependencies). SearchInput onChange method expects `event` as its first argument and then the actual string. 