### PR TITLE
Exclude markdown pre black background for code blocks

### DIFF
--- a/packages/module/src/styles/_dark-custom-override.scss
+++ b/packages/module/src/styles/_dark-custom-override.scss
@@ -22,7 +22,7 @@
     color: var(--pf-v5-global--palette--black-200) !important;
   }
 
-  .pfext-markdown-view pre {
+  .pfext-markdown-view pre:not(.pfext-code-block__pre) {
     background-color: var(--pf-v5-global--BackgroundColor--100);
     border-color: var(--pf-v5-global--BorderColor--100);
   }


### PR DESCRIPTION
###Before
<img width="510" alt="image" src="https://github.com/patternfly/patternfly-quickstarts/assets/96431149/2731c229-e90d-478c-9b24-985f0da9ab4f">


###After
<img width="510" alt="image" src="https://github.com/patternfly/patternfly-quickstarts/assets/96431149/610745f5-b264-425c-8d1c-34771786b96b">
