### PR TITLE
Use same blue highlight for code tags outside of CodeBlock components

### DIFF
--- a/packages/module/src/styles/_dark-custom-override.scss
+++ b/packages/module/src/styles/_dark-custom-override.scss
@@ -27,7 +27,7 @@
     border-color: var(--pf-v5-global--BorderColor--100);
   }
 
-  .pfext-markdown-view code {
+  .pfext-markdown-view .pf-v5-c-code-block__code {
     color: var(--pf-v5-global--Color--100);
     background-color: var(--pf-v5-global--palette--black-600);
   }


### PR DESCRIPTION
Before
<img width="543" alt="image" src="https://github.com/patternfly/patternfly-quickstarts/assets/96431149/20776bae-8d13-4b87-bc84-baefb13dcdff">


After
<img width="543" alt="image" src="https://github.com/patternfly/patternfly-quickstarts/assets/96431149/2fde4815-87ae-4d0d-8891-ef27216f9f24">
