### PR TITLE
chore(deps): Update peerDep for react-core to v5

### DIFF
--- a/packages/module/package.json
+++ b/packages/module/package.json
@@ -45,7 +45,7 @@
     "docs:copy": "mkdir -p dist/patternfly-docs && cp -R patternfly-docs/content/extensions/quick-starts dist/patternfly-docs"
   },
   "peerDependencies": {
-    "@patternfly/react-core": ">=4.115.2",
+    "@patternfly/react-core": ">=5.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "showdown": ">=1.8.6"


### PR DESCRIPTION
Closes https://github.com/patternfly/patternfly-quickstarts/issues/227