### PR TITLE
fix(quickstart tile): opening quickstarts on click event

### DIFF
--- a/packages/module/src/catalog/QuickStartTile.tsx
+++ b/packages/module/src/catalog/QuickStartTile.tsx
@@ -72,14 +72,14 @@ const QuickStartTile: React.FC<QuickStartTileProps> = ({
       if (link) {
         window.open(link.href);
       } else {
-        setActiveQuickStart(name, tasks?.length);
+        setActiveQuickStart(id, tasks?.length);
       }
       onClick();
     }
   };
 
   return (
-    <div ref={ref}>
+    <div ref={ref} onClick={handleClick}>
       <CatalogTile
         id={id + '-catalog-tile'}
         style={{
@@ -99,7 +99,6 @@ const QuickStartTile: React.FC<QuickStartTileProps> = ({
             action={action}
           />
         }
-        onClick={handleClick}
         onKeyDown={(event) => {
           if (event.key === 'Enter' || event.key === ' ') {
             setActiveQuickStart(id, tasks?.length);


### PR DESCRIPTION
The quickstarts panel is not opening on tile click. Only on the `Enter` key press. Currently, the click is sending different arguments in the event handler.

Also the CatalogTile is for some reason blocking the click handler. I've moved it to the parent div so it is triggering again.