### PR TITLE
Allow disabling quickstart panel grabbing focus

### DIFF
--- a/packages/module/src/QuickStartPanelContent.tsx
+++ b/packages/module/src/QuickStartPanelContent.tsx
@@ -56,7 +56,7 @@ const QuickStartPanelContent: React.FC<QuickStartPanelContentProps> = ({
   ...props
 }) => {
   const titleRef = React.useRef(null);
-  const { getResource, activeQuickStartState } =
+  const { getResource, activeQuickStartState, focusOnQuickStart } =
     React.useContext<QuickStartContextValues>(QuickStartContext);
   const [contentRef, setContentRef] = React.useState<HTMLDivElement>();
   const shadows = useScrollShadows(contentRef);
@@ -90,10 +90,10 @@ const QuickStartPanelContent: React.FC<QuickStartPanelContentProps> = ({
   };
 
   React.useEffect(() => {
-    if (quickStart) {
+    if (focusOnQuickStart && quickStart) {
       titleRef.current.focus();
     }
-  }, [quickStart]);
+  }, [focusOnQuickStart, quickStart]);
 
   const content = quickStart ? (
     <DrawerPanelContent

--- a/packages/module/src/controller/QuickStartTaskHeader.tsx
+++ b/packages/module/src/controller/QuickStartTaskHeader.tsx
@@ -66,12 +66,14 @@ const QuickStartTaskHeader: React.FC<QuickStartTaskHeaderProps> = ({
   children,
 }) => {
   const titleRef = React.useRef(null);
+  const { focusOnQuickStart } = React.useContext(QuickStartContext);
+
   React.useEffect(() => {
-    if (isActiveTask) {
+    if (focusOnQuickStart && isActiveTask) {
       // Focus the WizardNavItem button element that contains the title
       titleRef.current.parentNode.focus();
     }
-  }, [isActiveTask]);
+  }, [focusOnQuickStart, isActiveTask]);
   const classNames = css('pfext-quick-start-task-header__title', {
     'pfext-quick-start-task-header__title-success': taskStatus === QuickStartTaskStatus.SUCCESS,
     'pfext-quick-start-task-header__title-failed':

--- a/packages/module/src/utils/quick-start-context.tsx
+++ b/packages/module/src/utils/quick-start-context.tsx
@@ -79,6 +79,7 @@ export interface QuickStartContextValues {
   setLoading?: any;
   alwaysShowTaskReview?: boolean;
   setAlwaysShowTaskReview?: any;
+  focusOnQuickStart?: boolean;
 }
 
 export const QuickStartContextDefaults = {
@@ -104,6 +105,7 @@ export const QuickStartContextDefaults = {
   markdown: null,
   loading: false,
   alwaysShowTaskReview: true,
+  focusOnQuickStart: true,
 };
 export const QuickStartContext = createContext<QuickStartContextValues>(QuickStartContextDefaults);
 


### PR DESCRIPTION
I'm working on an application that provides a UI for people making QuickStart files. As part of this, I'm trying to use `QuickStartDrawer` to render a preview of the QuickStart. However, if the QuickStart is a QuickStart with tasks, thus opening the side panel, whenever the values in the QuickStart are changed, the panel grabs focus.

For instance, if I have a textbox that allows editing the description of a QuickStart, the user will enter a character into the textbox. That will result in the QuickStart being changed in the `QuickStartContext`. This will propagate down to `QuickStartPanel` and trigger [this hook](https://github.com/randomnetcat/patternfly-quickstarts/blob/c6f8c67fa7789c480f85f08bce8c6239f3926b3d/packages/module/src/QuickStartPanelContent.tsx#L92-L96) and pull focus to the panel, away from the textbox the user was editing.

To allow working around this, I am proposing to allow disabling everything that pulls focus to the panel with a new value in `QuickStartContext`. This value defaults to the status quo to preserve backwards-compatibility.