### PR TITLE
chore: add `packageManager` field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "This library provides the quickstarts module",
   "license": "MIT",
   "private": true,
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "workspaces": [
     "packages/dev",
     "packages/module",


### PR DESCRIPTION
Adds the `packageManager` field to `package.json` so that users of [Corepack](https://nodejs.org/api/corepack.html) will get the correct version of Yarn when installing dependencies.