### PR TITLE
Added link to UXD Hub content guidelines

### DIFF
--- a/packages/module/patternfly-docs/content/extensions/quick-starts/design-guidelines/design-guidelines.md
+++ b/packages/module/patternfly-docs/content/extensions/quick-starts/design-guidelines/design-guidelines.md
@@ -98,7 +98,7 @@ Here are some general guidelines to follow when authoring quick start content:
   * Provide links at the end of quick starts if the user is likely to need or want additional technical  information upon completion.
   * Provide links in the check your work module when a user answers **No** if more robust information can help the user understand what actions they must take to complete the task.  
 
-For more specific quick start content guidelines, refer to the [Red Hat OpenShift documentation](https://docs.openshift.com/container-platform/4.7/web_console/creating-quick-start-tutorials.html). While these guidelines are geared toward Red Hat OpenShift, they can apply to quick starts in any product.
+For more specific quick start content guidelines, refer to _Best practices for writing quick starts_ on [UXD Hub](https://www.uxd-hub.com/entries/resource/best-practices-for-writing-quick-starts). The [Red Hat OpenShift documentation](https://docs.openshift.com/container-platform/4.16/web_console/creating-quick-start-tutorials.html) contains similar guidelines geared toward Red Hat OpenShift.
 
 ## Quick starts in context
 


### PR DESCRIPTION
Updated design-guidelines.md with a link to the definitive quick starts style/content guidelines, created by Red Hat UXD & docs teams. 

The aim of the UXD Hub resource is to combine the guidance from all the various guidelines/best practices for writing PatternFly quick starts to help folks create more consistent quick starts following a single source of truth, especially in the Red Hat Hybrid Cloud Console. See https://issues.redhat.com/browse/HCCDOC-2517 for more info on this initiative.

We've also pulled in the relevant guidelines into the UXD Hub doc from the OpenShift doc mentioned here, but since the OpenShift docs link contains additional helpful content that is needed by those working in that space, it seemed to make sense to include both links. 

Feel free to edit my wording or let me know if I should make edits! Thanks for having a look and merging it :) CC: @nicolethoen