### PR TITLE
fix(quickstarts): restructure components to correct spacing and remove divider below toolbar

### DIFF
--- a/packages/dev/src/AppCustomDrawer.tsx
+++ b/packages/dev/src/AppCustomDrawer.tsx
@@ -1,6 +1,7 @@
 import './App.css';
 import {
   Page,
+  PageSection,
   Button,
   Drawer,
   DrawerContent,
@@ -11,6 +12,8 @@ import {
   DrawerPanelDescription,
   DrawerPanelBody,
   DrawerContentBody,
+  Stack,
+  StackItem,
 } from '@patternfly/react-core';
 import {
   LoadingBox,
@@ -140,24 +143,34 @@ const App: React.FC<AppProps> = ({ children, showCardFooters }) => {
           >
             <DrawerContentBody>
               <Page masthead={AppHeader} sidebar={AppSidebar} isManagedSidebar>
-                <Button
-                  variant="secondary"
-                  onClick={() => {
-                    toggleQuickStart('getting-started-with-quick-starts');
-                    setDrawerContent('quickstart');
-                  }}
-                >
-                  Getting started with quick starts
-                </Button>
-                <Button
-                  variant="secondary"
-                  onClick={() => {
-                    setActiveQuickStartID('');
-                    setDrawerContent('custom');
-                  }}
-                >
-                  Open a different drawer
-                </Button>
+                <PageSection>
+                  <Stack hasGutter>
+                    <StackItem>
+                      <Button
+                        variant="secondary"
+                        isBlock
+                        onClick={() => {
+                          toggleQuickStart('getting-started-with-quick-starts');
+                          setDrawerContent('quickstart');
+                        }}
+                      >
+                        Getting started with quick starts
+                      </Button>
+                    </StackItem>
+                    <StackItem>
+                      <Button
+                        variant="secondary"
+                        isBlock
+                        onClick={() => {
+                          setActiveQuickStartID('');
+                          setDrawerContent('custom');
+                        }}
+                      >
+                        Open a different drawer
+                      </Button>
+                    </StackItem>
+                  </Stack>
+                </PageSection>
                 {children}
               </Page>
             </DrawerContentBody>

--- a/packages/dev/src/AppProps.tsx
+++ b/packages/dev/src/AppProps.tsx
@@ -1,5 +1,5 @@
 import './App.css';
-import { Page, Button } from '@patternfly/react-core';
+import { Page, Button, PageSection } from '@patternfly/react-core';
 import {
   LoadingBox,
   QuickStartContainer,
@@ -80,12 +80,15 @@ const App: React.FC<AppProps> = ({ children, showCardFooters }) => {
     <React.Suspense fallback={<LoadingBox />}>
       <QuickStartContainer {...drawerProps}>
         <Page masthead={AppHeader} sidebar={AppSidebar} isManagedSidebar>
-          <Button
-            variant="secondary"
-            onClick={() => toggleQuickStart('getting-started-with-quick-starts')}
-          >
-            Getting started with quick starts
-          </Button>
+          <PageSection>
+            <Button
+              variant="secondary"
+              isBlock
+              onClick={() => toggleQuickStart('getting-started-with-quick-starts')}
+            >
+              Getting started with quick starts
+            </Button>
+          </PageSection>
           {children}
         </Page>
       </QuickStartContainer>

--- a/packages/dev/src/CustomCatalog.tsx
+++ b/packages/dev/src/CustomCatalog.tsx
@@ -238,9 +238,13 @@ export const CustomCatalog: React.FC = () => {
 
   return (
     <>
-      <PageSection hasBodyWrapper={false}>
+      <PageSection>
         <QuickStartCatalogHeader title="Resources" />
+      </PageSection>
+      <PageSection>
         <Divider component="div" />
+      </PageSection>
+      <PageSection>
         <QuickStartCatalogToolbar>
           <ToolbarContent>
             <QuickStartCatalogFilterSearchWrapper onSearchInputChange={onSearchInputChange} />
@@ -248,7 +252,6 @@ export const CustomCatalog: React.FC = () => {
             <QuickStartCatalogFilterCountWrapper quickStartsCount={filteredQuickStarts.length} />
           </ToolbarContent>
         </QuickStartCatalogToolbar>
-        <Divider component="div" />
       </PageSection>
       <PageSection hasBodyWrapper={false}>{quickStartCatalog()}</PageSection>
     </>

--- a/packages/module/src/QuickStartCatalogPage.tsx
+++ b/packages/module/src/QuickStartCatalogPage.tsx
@@ -181,7 +181,6 @@ export const QuickStartCatalogPage: React.FC<QuickStartCatalogPageProps> = ({
                 onSearchInputChange={onSearchInputChange}
                 onStatusChange={onStatusChange}
               />
-              <Divider component="div" />
             </>
           )}
         </PageSection>


### PR DESCRIPTION
Fixes https://github.com/patternfly/patternfly/issues/7332
Minor adjustments to space buttons

**After**
![Screenshot 2025-02-24 at 3 14 53 PM](https://github.com/user-attachments/assets/fcec1d9a-ee37-4bc8-9bed-6c8557840ac6)

**Current**
https://quickstarts.netlify.app/
