### PR TITLE
fix(QuickStartCatalogFilter): remove redundant toolbar padding

### DIFF
--- a/packages/module/src/catalog/Toolbar/QuickStartCatalogFilter.tsx
+++ b/packages/module/src/catalog/Toolbar/QuickStartCatalogFilter.tsx
@@ -18,7 +18,7 @@ const QuickStartCatalogFilter: React.FC<QuickStartCatalogFilterProps> = ({
   onStatusChange = () => {},
   ...props
 }) => (
-  <Toolbar {...props}>
+  <Toolbar hasNoPadding {...props}>
     <ToolbarContent>
       <QuickStartCatalogFilterSearchWrapper onSearchInputChange={onSearchInputChange} />
       <QuickStartCatalogFilterStatusWrapper onStatusChange={onStatusChange} />


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/72f942e6-cc49-4d88-9864-4421c9592613)

after:
![image](https://github.com/user-attachments/assets/2e0a9bb1-6ce6-4ad6-a948-25a4dce8b688)
