### PR TITLE
fix(spotlight): return missing scss file

### DIFF
--- a/packages/module/src/ConsoleShared/src/components/spotlight/InteractiveSpotlight.tsx
+++ b/packages/module/src/ConsoleShared/src/components/spotlight/InteractiveSpotlight.tsx
@@ -1,3 +1,4 @@
+import './spotlight.scss';
 import * as React from 'react';
 import { Portal, SimplePopper } from '../popper';
 

--- a/packages/module/src/ConsoleShared/src/components/spotlight/StaticSpotlight.tsx
+++ b/packages/module/src/ConsoleShared/src/components/spotlight/StaticSpotlight.tsx
@@ -1,3 +1,4 @@
+import './spotlight.scss';
 import * as React from 'react';
 import { useBoundingClientRect } from '../../hooks';
 import Portal from '../popper/Portal';

--- a/packages/module/src/ConsoleShared/src/components/spotlight/spotlight.scss
+++ b/packages/module/src/ConsoleShared/src/components/spotlight/spotlight.scss
@@ -1,0 +1,63 @@
+@keyframes pfext-spotlight-expand {
+    0% {
+      outline-offset: -4px;
+      outline-width: 4px;
+      opacity: 1;
+    }
+    100% {
+      outline-offset: 21px;
+      outline-width: 12px;
+      opacity: 0;
+    }
+  }
+  
+  @keyframes pfext-spotlight-fade-in {
+    0% {
+      opacity: 0;
+    }
+    100% {
+      opacity: 1;
+    }
+  }
+  
+  @keyframes pfext-spotlight-fade-out {
+    0% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 0;
+    }
+  }
+  
+  .pfext-spotlight {
+    pointer-events: none;
+    position: absolute;
+    &__with-backdrop {
+      mix-blend-mode: hard-light;
+    }
+    &__element-highlight-noanimate {
+      border: var(--pf-t--global--border--width--strong) solid var(--pf-t--global--border--color--brand--default);
+      background-color: var(--pf-t--color--gray--40);
+      z-index: 9999;
+    }
+    &__element-highlight-animate {
+      pointer-events: none;
+      position: absolute;
+      box-shadow: inset 0px 0px 0px 4px var(--pf-t--global--color--brand--default);
+      opacity: 0;
+      animation: 0.4s pfext-spotlight-fade-in 0s ease-in-out, 5s pfext-spotlight-fade-out 12.8s ease-in-out;
+      animation-fill-mode: forwards;
+      &::after {
+        content: '';
+        position: absolute;
+        left: 0;
+        right: 0;
+        top: 0;
+        bottom: 0;
+        animation: 1.2s pfext-spotlight-expand 1.6s ease-out;
+        animation-fill-mode: forwards;
+        outline: 4px solid var(--pf-t--global--color--brand--default);
+        outline-offset: -4px;
+      }
+    }
+  }


### PR DESCRIPTION
OCP reported that the spotlight CSS was missing in PF6 causing their spotlight feature to cease to work in 4.19.
This PR returns the missing CSS


## To demonstrate the issue (before this fix)
Before:

![Screenshot 2025-04-16 at 5 04 39 PM](https://github.com/user-attachments/assets/80287c30-abad-4c6b-bf63-1b6df0c43f59)

After:

![Screenshot 2025-04-16 at 5 02 54 PM](https://github.com/user-attachments/assets/7ac96f1f-9b8a-4d90-9f56-efd24be806a2)
