### PR TITLE
Fix: item count number is not correctly shown for Quick start catalog …

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,3 @@ yarn build
 # Quick build of the main module for local dev
 yarn build:quick
 ```
-

--- a/packages/module/src/catalog/Toolbar/QuickStartCatalogFilterItems.tsx
+++ b/packages/module/src/catalog/Toolbar/QuickStartCatalogFilterItems.tsx
@@ -72,7 +72,7 @@ export const QuickStartCatalogFilterCount = ({ quickStartsCount }) => {
   const { getResource } = useContext<QuickStartContextValues>(QuickStartContext);
   return (
     <ToolbarItem align={{ default: 'alignEnd' }}>
-      {getResource('{{count, number}} item', quickStartsCount)}
+      { getResource("{{count, number}} item", quickStartsCount).replace('{{count, number}}', quickStartsCount) }
     </ToolbarItem>
   );
 };


### PR DESCRIPTION
Fix for https://github.com/patternfly/patternfly-quickstarts/issues/412

The `getResource` function handles pluralization by referring to a JSON hash map
https://github.com/patternfly/patternfly-quickstarts/blob/main/packages/module/src/locales/en/quickstart.json

I am assuming `{{ count, number }}` is indicating that `count` should be of type `number`.